### PR TITLE
Small fix to a problem while resolving sonatype snapshots

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,2 +1,3 @@
+resolvers += Resolver.sonatypeRepo("snapshots")
 addSbtPlugin("org.scala-exercises" % "sbt-exercise" % "0.2.1-SNAPSHOT", "0.13", "2.10")
 addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.0.0")


### PR DESCRIPTION
This PR tries to fix a problem that sbt may have in some versions, in which tries to download the dependencies from the project **before** actually loading the resolvers for those.

Could you please review, @juanpedromoreno? Thanks!!