### PR TITLE
Removed excerpts of text from the sections

### DIFF
--- a/src/main/scala/fpinscalalib/ErrorHandlingSection.scala
+++ b/src/main/scala/fpinscalalib/ErrorHandlingSection.scala
@@ -15,50 +15,17 @@ object ErrorHandlingSection extends FlatSpec with Matchers with org.scalaexercis
     *
     * The following set of sections represent the exercises contained in the book "Functional Programming in Scala",
     * written by Paul Chiusano and Rúnar Bjarnason and published by Manning. This content library is meant to be used
-    * in tandem with the book, although excerpts of the theory needed to complete them have been added to guide you.
+    * in tandem with the book. We use the same numeration for the exercises for you to follow them.
     *
     * For more information about "Functional Programming in Scala" please visit its
     * <a href="https://www.manning.com/books/functional-programming-in-scala">official website</a>.
     *
     * = The Option data type =
     *
-    * Exceptions break referential transparency and introduce context dependence. Moreover, they are not type-safe,
-    * hiding information about the fact that they may occur, to the developer and the compiler. We're going to explore
-    * an alternative to exceptions without these drawbacks, without losing out on the primary benefit of exceptions:
-    * they allow us to `consolidate and centralize error-handling logic`. The technique we use is based on an old idea:
-    * instead of throwing an exception, we return a value indicating that an exceptional condition has occurred. instead
-    * of using error codes, we introduce a new generic type for these “possibly defined values” and use higher-order
-    * functions to encapsulate common patterns of handling and propagating errors.
+    * <b>Exercise 4.1</b>:
     *
-    * We're going to introduce a new type, `Option`. As with the previously explored `List`, this type also exists in
-    * the Scala standard library, but we're re-creating it here for pedagogical purposes:
-    *
-    * {{{
-    *   sealed trait Option[+A]
-    *   case class Some[+A](get: A) extends Option[A]
-    *   case object None extends Option[Nothing]
-    * }}}
-    *
-    * Option has two cases: it can be defined, in which case it will be a `Some`, or it can be undefined, in which case
-    * it will be `None`.
-    *
-    * Let's consider an example on how we can use our new type. We're defining a function `mean` that computes the mean
-    * of a list, which is undefined if the list is empty:
-    */
-
-  def optionMeanAssert(res0: Option[Double]): Unit = {
-    def mean(xs: Seq[Double]): Option[Double] =
-      if (xs.isEmpty) None
-      else Some(xs.sum / xs.length)
-
-    mean(Seq(1, 2, 3, 4, 5)) shouldBe Some(3.0)
-    mean(Seq.empty) shouldBe res0
-  }
-
-  /**
-    * `Option` can be thought of like a `List` that can contain at most one element, and many of the `List` functions we
-    * saw earlier have analogous functions on `Option`. We're going to look at some of these functions, starting by `map`,
-    * that applies a function `f` in the `Option` is not `None`:
+    * We're going to look at some of the functions available in the `Option`, starting by `map`, that applies a function
+    * `f` in the `Option` is not `None`:
     *
     * {{{
     *   def map[B](f: A => B): Option[B] = this match {
@@ -98,8 +65,7 @@ object ErrorHandlingSection extends FlatSpec with Matchers with org.scalaexercis
     *   def flatMap[B](f: A => Option[B]): Option[B] = map(f) getOrElse None
     * }}}
     *
-    * By using `flatMap` we can chain operations that can also fail, as in the following example. Try to find out who is
-    * managing each employee, if applicable:
+    * Try to find out who is managing each employee, if applicable:
     */
 
   def optionFlatMapAssert(res0: (Option[Employee]) => Option[String]): Unit = {
@@ -111,10 +77,8 @@ object ErrorHandlingSection extends FlatSpec with Matchers with org.scalaexercis
   }
 
   /**
-    * The function `getOrElse` used above, tries to get the value contained in the Option, but if it's a `None`, it will
-    * return the default value provided by the caller. The `B >: A` in the declaration tells that the `B` type parameter
-    * must be a supertype of `A`. Furthermore, `default : => B` indicates that the argument is of type B, but won’t be
-    * evaluated until it’s needed by the function.
+    * The function `getOrElse` tries to get the value contained in the Option, but if it's a `None`, it will
+    * return the default value provided by the caller:
     *
     * {{{
     *   def getOrElse[B>:A](default: => B): B = this match {
@@ -129,6 +93,8 @@ object ErrorHandlingSection extends FlatSpec with Matchers with org.scalaexercis
     * {{{
     *   def orElse[B>:A](ob: => Option[B]): Option[B] = this map (Some(_)) getOrElse ob
     * }}}
+    *
+    * Check how it works in the following exercise:
     */
 
   def optionOrElseAssert(res0: Some[String], res1: Some[String], res2: Some[String]): Unit = {
@@ -139,7 +105,8 @@ object ErrorHandlingSection extends FlatSpec with Matchers with org.scalaexercis
     getManager(lookupByName("Foo")).orElse(Some("Mr. CEO")) shouldBe res2
   }
 
-  /** Finally, we can implement a `filter` function that will turn any `Option` into a `None` if it doesn't satisfy the
+  /**
+    * Finally, we can implement a `filter` function that will turn any `Option` into a `None` if it doesn't satisfy the
     * provided predicate:
     *
     * {{{
@@ -159,6 +126,8 @@ object ErrorHandlingSection extends FlatSpec with Matchers with org.scalaexercis
   }
 
   /**
+    * <b>Exercise 4.2:</b>
+    *
     * Let's implement the `variance` function in terms of `flatMap`. If the mean of a sequence is `m`, the variance
     * is the mean of `math.pow(x - m, 2)` for each element in the sequence:
     *
@@ -169,39 +138,22 @@ object ErrorHandlingSection extends FlatSpec with Matchers with org.scalaexercis
     */
 
   /**
-    * We may find in some situations when we need to combine two `Option` values using a binary function, so that if any
-    * of those values is `None`, the result value is too; and otherwise it will be the result of applying the provided
-    * function. We'll call this function `map2`, take a look at its implementation:
+    * <b>Exercise 4.3:</b>
+    *
+    * Let's write a generic function to combine two `Option` values , so that if any of those values is `None`, the
+    * result value is too; and otherwise it will be the result of applying the provided function:
     *
     * {{{
     *   def map2[A,B,C](a: Option[A], b: Option[B])(f: (A, B) => C): Option[C] =
     *     a flatMap (aa => b map (bb => f(aa, bb)))
     * }}}
     *
-    * Let's see an example of its use. Let's write a function `parseInsuranceRateQuote` which takes the age and a number
-    * of speeding tickets as strings, and attempts to call another function called `insuranceRateQuote` if parsing both
-    * values is valid:
+    * <b>Exercise 4.4:</b>
     *
-    * {{{
-    *   def Try[A](a: => A): Option[A] =
-    *     try Some(a)
-    *     catch { case e: Exception => None }
-    *
-    *   def parseInsuranceRateQuote( age: String, numberOfSpeedingTickets: String): Option[Double] = {
-    *     val optAge: Option[Int] = Try { age.toInt }
-    *     val optTickets: Option[Int] = Try { numberOfSpeedingTickets.toInt } map2(optAge, optTickes)(insuranceRateQuote)
-    *   }
-    * }}}
-    *
-    * As `Try` will return an `Option` containing the value of the operation it encapsulates (or a `None` if it returns
-    * an exception), to combine both values we need to make use of the new `map2` function we just implemented.
-    */
-
-  /**
     * Let's continue by looking at a few other similar cases. For instance, the `sequence` function, which combines a list
-    * of `Option`s into one `Option` containing a list of all the `Some` values in the original list. If the original
-    * list contains `None` even once, the result of the function should be `None`. Otherwise the result should be a `Some`
-    * with a list of all the values:
+    * of `Option`s into another `Option` containing a list of all the `Some`s in the original one. If the original
+    * list contains `None` at least once, the result of the function should be `None`. If not, the result should be a
+    * `Some` with a list of all the values:
     *
     * {{{
     *   def sequence(a: List[Option[A]]): Option[List[A]] = a match {
@@ -219,10 +171,10 @@ object ErrorHandlingSection extends FlatSpec with Matchers with org.scalaexercis
   }
 
   /**
+    * <b>Exercise 4.5:</b>
+    *
     * The last `Option` function we're going to explore is `traverse`, that will allow us to map over a list using a
-    * function that might fail, returning `None` if applying it to any element of the list returns `None`. Note that we
-    * want to avoid traversing the list twice (first to apply the provided function to each element, and another to
-    * combine these `Option` values into an optional `List`:
+    * function that might fail, returning `None` if applying it to any element of the list returns `None`:
     *
     * {{{
     *   def traverse[A, B](a: List[A])(f: A => Option[B]): Option[List[B]] = a match {
@@ -263,39 +215,8 @@ object ErrorHandlingSection extends FlatSpec with Matchers with org.scalaexercis
   /**
     * = The Either data type =
     *
-    * One thing you may have noticed with `Option` is that it doesn’t tell us anything about what went wrong in the case
-    * of an exceptional condition. All it can do is give us `None`, indicating that there’s no value to be had. But
-    * sometimes we want to know more. For example, we might want a `String` that gives more information, or if an
-    * exception was raised, we might want to know what that error actually was.
+    * <b>Exercise 4.6:</b>
     *
-    * In this section, we’ll walk through a simple extension to `Option`, the `Either` data type, which lets us track a
-    * reason for the failure. Let’s look at its definition:
-    *
-    * {{{
-    *   sealed trait Either[+E, +A]
-    *   case class Left[+E](value: E) extends Either[E, Nothing]
-    *   case class Right[+A](value: A) extends Either[Nothing, A]
-    * }}}
-    *
-    * `Either` only has two cases, just like `Option`. The essential difference is that both cases carry a value. When
-    * we use it to indicate success or failure, by convention the `Right` constructor is reserved for the success case
-    * (a pun on “right,” meaning correct), and `Left` is used for failure.
-    *
-    * Let's look at the `mean` example again, this time returning a `String` in case of failure:
-    */
-
-  def eitherMeanAssert(res0: Right[Double], res1: Left[String]): Unit = {
-    def mean(xs: IndexedSeq[Double]): Either[String, Double] =
-      if (xs.isEmpty)
-        Left("mean of empty list!")
-      else
-        Right(xs.sum / xs.length)
-
-    mean(IndexedSeq(1.0, 2.0, 3.0, 4.0, 5.0)) shouldBe res0
-    mean(IndexedSeq.empty) shouldBe res1
-  }
-
-  /**
     * As we did with `Option`, let's implement versions of `map`, `flatMap`, `orElse` and `map2` on `Either` that
     * operate on the `Right` value, starting with `map`:
     *
@@ -409,8 +330,10 @@ object ErrorHandlingSection extends FlatSpec with Matchers with org.scalaexercis
   }
 
   /**
-    * `sequence` and `traverse` can also be implemented for `Either`. These should return the first error that's
-    * encountered, if there is one.
+    * <b>Exercise 4.7:</b>
+    *
+    * `sequence` and `traverse` can also be implemented for `Either`. Those functions should return the first error that
+    * can be found, if there is one.
     *
     * {{{
     *   def traverse[E,A,B](es: List[A])(f: A => Either[E, B]): Either[E, List[B]] = es match {

--- a/src/main/scala/fpinscalalib/FunctionalDataStructuresSection.scala
+++ b/src/main/scala/fpinscalalib/FunctionalDataStructuresSection.scala
@@ -15,83 +15,14 @@ object FunctionalDataStructuresSection extends FlatSpec with Matchers with org.s
     *
     * The following set of sections represent the exercises contained in the book "Functional Programming in Scala",
     * written by Paul Chiusano and Rúnar Bjarnason and published by Manning. This content library is meant to be used
-    * in tandem with the book, although excerpts of the theory needed to complete them have been added to guide you.
+    * in tandem with the book. We use the same numeration for the exercises for you to follow them.
     *
     * For more information about "Functional Programming in Scala" please visit its
     * <a href="https://www.manning.com/books/functional-programming-in-scala">official website</a>.
     *
     * = Singly linked lists =
     *
-    * Let's examine what's probably the most ubiquitous functional data structure, the singly-linked list to start. The
-    * definition here is identical in spirit to (though simpler than) the `List` data type defined in Scala's standard
-    * library.
-    *
-    * {{{
-    * sealed trait List[+A]
-    * case object Nil extends List[Nothing]
-    *
-    * object List {
-    *   def sum(ints: List[Int]): Int = ints match {
-    *     case Nil => 0
-    *     case Cons(x,xs) => x + sum(xs)
-    *   }
-    *
-    *   def product(ds: List[Double]): Double = ds match {
-    *     case Nil => 1.0
-    *     case Cons(0.0, _) => 0.0
-    *     case Cons(x,xs) => x * product(xs)
-    *   }
-    *
-    *   def apply[A](as: A*): List[A] =
-    *     if (as.isEmpty) Nil
-	  *     else Cons(as.head, apply(as.tail: _*))
-    * }
-    * }}}
-    *
-    * The definition of the data type begins with the keywords `sealed trait`. In general, we introduce a data type with
-    * the `trait` keyword. A `trait` is an abstract interface that may optionally contain implementations of some
-    * methods. There are two such implementations, or data constructors, of `List`, to represent the two possible forms a
-    * `List` can take. A `List` can be empty (denoted by the data constructor `Nil`), or it can be nonempty, denoted by
-    * the data constructor `Cons` (traditionally short for `construct`). A nonempty list consists of an initial element,
-    * `head`, followed by a (possibly empty) `List` of remaining elements (the `tail`).
-    *
-    * = Pattern matching =
-    *
-    * Each data constructor also introduces a `pattern` that can be used for `pattern matching`, as in the functions
-    * `sum` and `product`. Both functions are defined in the `object` `List`, sometimes called the `companion object` to
-    * `List`. Both definitions make use of pattern matching.
-    *
-    * As you might expect, the `sum` function states that the sum of an empty list is 0, and the sum of a nonempty list
-    * is the first element, `x`, plus the sum of the remaining elements, `xs`. Likewise, the `product` definition states
-    * that the product of an empty list is `1.0`, the product of any other nonempty list starting with `0.0` is `0.0`,
-    * and the product of any other nonempty list is the first element multiplied by the product of the remaining elements.
-    *
-    * Pattern matching works a bit like a fancy `switch` statement that may descend into the structure of the expression
-    * it examines and extract subexpressions of that structure. Each case in the match consists of a `pattern` (like
-    * `Cons(x, xs)`), and a `result` (like `x * product(xs)`). If the target `matches` the pattern in a case, the result
-    * of that case becomes the result of the entire match expression. If multiple patterns match the target, Scala chooses
-    * the first matching case. Let's look at some examples:
-    */
-
-  def patternMatching101Assert(res0: Int, res1: Int, res2: List[Int]) {
-    (List(1, 2, 3) match { case _ => 42 }) shouldBe res0
-    (List(1, 2, 3) match { case Cons(h, _) => h }) shouldBe res1
-    (List(1, 2, 3) match { case Cons(_, t) => t }) shouldBe res2
-  }
-
-  /**
-    * The following example is a little bit different:
-    *
-    * {{{
-    *   List(1, 2, 3) match { case Nil => 42 }
-    * }}}
-    *
-    * What happens if not a single case in a match expression matches the target? Scala will return a `MatchError` at
-    * runtime.
-    *
-    * A pattern may contain `literals` (like `3` or `"hi"`), `variables` like `x` and `xs`, which match anything,
-    * indicated by an identifier starting with a lowercase letter or underscore; and data constructors like `Cons(x, xs)`
-    * and `Nil`, which match only values of the corresponding form. These components may be nested arbitrarily.
+    * <b>Exercise 3.1:</b>
     *
     * Examine the next complex match expression. What will be the result?
     */
@@ -108,61 +39,50 @@ object FunctionalDataStructuresSection extends FlatSpec with Matchers with org.s
   }
 
   /**
-    * Let's try implementing a few different functions for modifying lists in different ways. First, we'll implement the
-    * function `tail` for removing the first element of a `List`. Also take a look at how we handle the use of `take` on
-    * `Nil` lists:
+    * <b>Exercise 3.2:</b>
     *
-    * {{{
-    *   def tail[A](l: List[A]): List[A] =
-    *     l match {
-    *     case Nil => sys.error("tail of empty list")
-    *     case Cons(_,t) => t
-    *     }
-    * }}}
-    *
-    * After taking a look at its implementation, check out its behaviour on the following cases:
+    * Take a look at the implementation of `List`'s `tail` function, and check its behaviour on the following cases:
     */
 
   def listTakeAssert(res0: List[Int], res1: List[Int]) {
+    def tail[A](l: List[A]): List[A] =
+      l match {
+        case Nil => sys.error("tail of empty list")
+        case Cons(_,t) => t
+      }
     tail(List(1, 2, 3)) shouldBe res0
     tail(List(1)) shouldBe res1
   }
 
   /**
-    * Using the same idea, we can implement the function `setHead` for replacing the first element of a List with a
-    * different value:
+    * <b>Exercise 3.3:</b>
     *
-    * {{{
-    *   def setHead[A](l: List[A], h: A): List[A] = l match {
-    *     case Nil => sys.error("setHead on empty list")
-    *     case Cons(_,t) => Cons(h,t)
-    *   }
-    * }}}
-    *
-    * Let's see how it behaves:
+    * `setHead` follows a similar principle. Let's take a look at how it works:
     */
 
   def listSetHeadAssert(res0: List[Int], res1: List[String]) {
+    def setHead[A](l: List[A], h: A): List[A] = l match {
+      case Nil => sys.error("setHead on empty list")
+      case Cons(_,t) => Cons(h,t)
+    }
     setHead(List(1, 2, 3), 3) shouldBe res0
     setHead(List("a", "b"), "c") shouldBe res1
   }
 
   /**
-    * We can generalize `take` to the function `drop`, which removes the first `n` elements from a list.
+    * <b>Exercise 3.4:</b>
     *
-    * {{{
-    *   def drop[A](l: List[A], n: Int): List[A] =
-    *     if (n <= 0) l
-    *     else l match {
-    *       case Nil => Nil
-    *       case Cons(_,t) => drop(t, n-1)
-    *     }
-    * }}}
-    *
-    * Again, we can see its behaviour with the following exercises:
+    * We can generalize `take` to the function `drop`:
     */
 
   def listDropAssert(res0: List[Int], res1: List[Int], res2: List[Int], res3: List[Int], res4: List[Int]) {
+    def drop[A](l: List[A], n: Int): List[A] =
+      if (n <= 0) l
+      else l match {
+        case Nil => Nil
+        case Cons(_,t) => drop(t, n - 1)
+      }
+
     drop(List(1, 2, 3), 1) shouldBe res0
     drop(List(1, 2, 3), 0) shouldBe res1
     drop(List("a", "b"), 2) shouldBe res2
@@ -171,21 +91,19 @@ object FunctionalDataStructuresSection extends FlatSpec with Matchers with org.s
   }
 
   /**
+    * <b>Exercise 3.5:</b>
+    *
     * `dropWhile` extends the behaviour of `drop`, removing elements from the `List` prefix as long as they match a
-    * predicate
-    *
-    * {{{
-    *   def dropWhile[A](l: List[A], f: A => Boolean): List[A] =
-    *     l match {
-    *       case Cons(h,t) if f(h) => dropWhile(t, f)
-    *       case _ => l
-    *     }
-    * }}}
-    *
-    * See how it works with the following examples:
+    * predicate. Study its implementation and check how it works with the following examples:
     */
 
   def listDropWhileAssert(res0: List[Int], res1: List[Int], res2: List[Int], res3: List[Int]) {
+    def dropWhile[A](l: List[A], f: A => Boolean): List[A] =
+      l match {
+        case Cons(h,t) if f(h) => dropWhile(t, f)
+        case _ => l
+      }
+
     dropWhile(List(1, 2, 3), (x: Int) => x < 2) shouldBe res0
     dropWhile(List(1, 2, 3), (x: Int) => x > 2) shouldBe res1
     dropWhile(List(1, 2, 3), (x: Int) => x > 0) shouldBe res2
@@ -193,22 +111,18 @@ object FunctionalDataStructuresSection extends FlatSpec with Matchers with org.s
   }
 
   /**
-    * In the same fashion, let's implement another function `init` that returns a `List` consisting of all but the last
-    * element of a `List`. It should be noted that this function cannot be implemented in constant time like `tail`.
+    * <b>Exercise 3.6:</b>
     *
-    * {{{
-    *   def init[A](l: List[A]): List[A] =
-    *     l match {
-    *       case Nil => sys.error("init of empty list")
-    *       case Cons(_,Nil) => Nil
-    *       case Cons(h,t) => Cons(h,init(t))
-    *     }
-    * }}}
-    *
-    * Let's look at how it works:
+    * `init` can be implemented in the same fashion, but cannot be implemented in constant time like `tail`:
     */
 
   def listInitAssert(res0: List[Int], res1: List[Int]) {
+    def init[A](l: List[A]): List[A] =
+      l match {
+        case Nil => sys.error("init of empty list")
+        case Cons(_,Nil) => Nil
+        case Cons(h,t) => Cons(h,init(t))
+      }
     init(List(1, 2, 3)) shouldBe res0
     init(List(1)) shouldBe res1
   }
@@ -216,47 +130,7 @@ object FunctionalDataStructuresSection extends FlatSpec with Matchers with org.s
   /**
     * = Recursion over lists and generalizing to higher-order functions =
     *
-    * Once again, let’s take a look at the implementations of `sum` and `product`. We’ve simplified the product
-    * implementation slightly, so as not to include the “short-circuiting” logic of checking for 0.0:
-    *
-    * {{{
-    * def sum(ints: List[Int]): Int = ints match {
-    *   case Nil => 0
-    *   case Cons(x,xs) => x + sum(xs)
-    *   }
-    *
-    * def product(ds: List[Double]): Double = ds match {
-    *   case Nil => 1.0
-    *   case Cons(x, xs) => x * product(xs)
-    *   }
-    * }}}
-    *
-    * Note how similar these two definitions are. They’re operating on different types (List[Int] versus List[Double]),
-    * but aside from this, the only differences are the value to return in the case that the list is empty (0 in the case
-    * of sum, 1.0 in the case of product), and the operation to combine results (+ in the case of sum, * in the case of
-    * product).
-    *
-    * We can improve things by generalizing those functions, by implementing a `foldRight`. This function will take on as
-    * arguments the value to return in the case of the empty list, and the function to add an element to the result in
-    * the case of a nonempty list:
-    *
-    * {{{
-    * def foldRight[A,B](as: List[A], z: B)(f: (A, B) => B): B =
-    *   as match {
-    *     case Nil => z
-    *     case Cons(x, xs) => f(x, foldRight(xs, z)(f))
-    *   }
-    *
-    * def sum2(ns: List[Int]) = foldRight(ns, 0)((x,y) => x + y)
-    * def product2(ns: List[Double]) = foldRight(ns, 1.0)(_ * _)
-    * }}}
-    *
-    * `foldRight` replaces the constructors of the list, `Nil` and `Cons`, with `z` and `f`, illustrated here:
-    *
-    * {{{
-    *   Cons(1, Cons(2, Nil))
-    *   f   (1, f   (2, z  ))
-    * }}}
+    * <b>Exercise 3.x:</b>
     *
     * Let's run through the steps that `foldRight` will follow in our new implementation of `sum2`:
     *
@@ -271,6 +145,8 @@ object FunctionalDataStructuresSection extends FlatSpec with Matchers with org.s
   }
 
   /**
+    * <b>Exercise 3.8:</b>
+    *
     * Now that we know how `foldRight` works, try to think about what happens when you pass `Nil` and `Cons` themselves
     * to `foldRight`.
     */
@@ -280,6 +156,8 @@ object FunctionalDataStructuresSection extends FlatSpec with Matchers with org.s
   }
 
   /**
+    * <b>Exercise 3.9:</b>
+    *
     * Let's try to use `foldRight` to calculate the length of a list. Try to fill the gaps in our implementation:
     */
 
@@ -291,9 +169,10 @@ object FunctionalDataStructuresSection extends FlatSpec with Matchers with org.s
   }
 
   /**
-    * Our implementation of `foldRight` is not tail-recursive and will result in a `StackOverflowError` for large lists
-    * (we say it's not `stack-safe`). Let's write another general list-recursion function, `foldLeft`, that is
-    * tail-recursive, using the techniques we discussed in the previous chapter:
+    * <b>Exercise 3.10:</b>
+    *
+    * Let's write another general tail-recursive list-recursion function, `foldLeft`, using the techniques we discussed
+    * in the previous chapter:
     *
     * {{{
     *   def foldLeft[A,B](l: List[A], z: B)(f: (B, A) => B): B =
@@ -302,6 +181,8 @@ object FunctionalDataStructuresSection extends FlatSpec with Matchers with org.s
     *       case Cons(h,t) => foldLeft(t, f(z,h))(f)
     *     }
     * }}}
+    *
+    * <b>Exercise 3.11:</b>
     *
     * Let's write functions `sum`, `product` and `length` of a list using `foldLeft`:
     */
@@ -319,12 +200,16 @@ object FunctionalDataStructuresSection extends FlatSpec with Matchers with org.s
   }
 
   /**
+    * <b>Exercise 3.12:</b>
+    *
     * As we saw above, we can write the previous functions we implemented using `foldRight` with `foldLeft`. Let's continue
     * with `reverse`:
     *
     * {{{
     *   def reverse[A](l: List[A]): List[A] = foldLeft(l, List[A]())((acc, h) => Cons(h, acc))
     * }}}
+    *
+    * <b>Exercise 3.13:</b>
     *
     * In fact, we can write `foldLeft` in terms of `foldRight`, and the other way around:
     *
@@ -336,13 +221,8 @@ object FunctionalDataStructuresSection extends FlatSpec with Matchers with org.s
     *     foldRight(l, (b:B) => b)((a,g) => b => g(f(b,a)))(z)
     * }}}
     *
-    * The implementation of `foldRight` in terms of `reverse` and `foldLeft` is a common trick for avoiding stack overflows
-    * when implementing a strict `foldRight` function as we've done in this chapter. Note that the other implementation is
-    * more of theoretical interest - it isn't stack-safe and won't work for large lists.
+    * <b>Exercise 3.14:</b>
     *
-    */
-
-  /**
     * Another function we can implement by using `foldRight` is `append`:
     *
     * {{{
@@ -361,6 +241,8 @@ object FunctionalDataStructuresSection extends FlatSpec with Matchers with org.s
   }
 
   /**
+    * <b>Exercise 3.15:</b>
+    *
     * `foldRight` can also be useful to write a function `concat` that concatenates a list of lists into a single list.
     * Take a look at its implementation:
     *
@@ -372,9 +254,10 @@ object FunctionalDataStructuresSection extends FlatSpec with Matchers with org.s
     * Since `append` takes time proportional to its first argument, and this first argument never grows because of the
     * right-associativity of `foldRight`, this function is linear in the total length of all lists.
     *
-    */
-
-  /**
+    * = More functions for working with lists =
+    *
+    * <b>Exercise 3.16:</b>
+    *
     * Let's keep digging into the uses of `foldLeft` and `foldRight`, by implementing a function that transforms a list
     * of integers by adding 1 to each element:
     */
@@ -385,15 +268,17 @@ object FunctionalDataStructuresSection extends FlatSpec with Matchers with org.s
   }
 
   /**
+    * <b>Exercise 3.17:</b>
+    *
     * We can do something similar to turn each value in a List[Double] into a String:
     *
     * {{{
     *   def doubleToString(l: List[Double]): List[String] =
     *     foldRight(l, Nil:List[String])((h,t) => Cons(h.toString,t))
     * }}}
-    */
-
-  /**
+    *
+    * <b>Exercise 3.18:</b>
+    *
     * Both `add1` and `doubleToString` modify each element in a list while maintaining its structure. We can generalize
     * it in the following way:
     *
@@ -402,27 +287,8 @@ object FunctionalDataStructuresSection extends FlatSpec with Matchers with org.s
     *     foldRight(l, Nil:List[B])((h,t) => Cons(f(h),t))
     * }}}
     *
-    * You may notice that we are using `foldRight` to implement `map`, even though it's not stack-safe. We can also
-    * use `foldRightViaFoldLeft` (that relies on reversing the original list), or use local mutation. Take a look at both
-    * alternatives:
+    * <b>Exercise 3.19:</b>
     *
-    * {{{
-    *   def map_1[A,B](l: List[A])(f: A => B): List[B] =
-    *     foldRightViaFoldLeft(l, Nil:List[B])((h,t) => Cons(f(h),t))
-    *
-    *   def map_2[A,B](l: List[A])(f: A => B): List[B] = {
-    *     val buf = new collection.mutable.ListBuffer[B]
-    *     def go(l: List[A]): Unit = l match {
-    *       case Nil => ()
-    *       case Cons(h,t) => buf += f(h); go(t)
-    *     }
-    *     go(l)
-    *     List(buf.toList: _*) // converting from the standard Scala list to the list we've defined here
-    *   }
-    * }}}
-    */
-
-  /**
     * Let's apply the same principle as we use in `map` to remove elements from a list, starting with a function to
     * remove all odd numbers from a List[Int]:
     */
@@ -433,20 +299,8 @@ object FunctionalDataStructuresSection extends FlatSpec with Matchers with org.s
   }
 
   /**
-    * Following the same principle, let's generalize the function above to be able to remove elements from a list unless
-    * they satisfy a given predicate:
+    * <b>Exercise 3.20:</b>
     *
-    * {{{
-    *   def filter[A](l: List[A])(f: A => Boolean): List[A] =
-    *     foldRight(l, Nil:List[A])((h,t) => if (f(h)) Cons(h,t) else t)
-    * }}}
-    *
-    * The same considerations regarding the different choices of implementations as in `map` apply to `filter`. The one
-    * above isn't stack-safe, so we should make a choice between using `foldRightViaFoldLeft` instead of `foldRight`, or
-    * perform local mutations.
-    */
-
-  /**
     * We're going to implement a new function that works like `map` except that the function given will return a list
     * instead of a single result, and that list should be inserted into the final resulting list:
     *
@@ -463,6 +317,8 @@ object FunctionalDataStructuresSection extends FlatSpec with Matchers with org.s
   }
 
   /**
+    * <b>Exercise 3.21:</b>
+    *
     * We can also implement `filter` using `flatMap`:
     *
     * {{{
@@ -473,8 +329,10 @@ object FunctionalDataStructuresSection extends FlatSpec with Matchers with org.s
     */
 
   /**
+    * <b>Exercise 3.22:</b>
+    *
     * Now we're going to write a function that accepts two lists of integers and constructs a new list by adding
-    * corresponding elements. For example, `List(1, 2, 3)` and `List(4, 5, 6)` become `List(5, 7, 9)`:
+    * corresponding elements. i.e.: `List(1, 2, 3)` and `List(4, 5, 6)` become `List(5, 7, 9)`:
     *
     * {{{
     *   def addPairwise(a: List[Int], b: List[Int]): List[Int] = (a,b) match {
@@ -483,6 +341,8 @@ object FunctionalDataStructuresSection extends FlatSpec with Matchers with org.s
     *     case (Cons(h1,t1), Cons(h2,t2)) => Cons(h1+h2, addPairwise(t1,t2))
     *   }
     * }}}
+    *
+    * <b>Exercise 3.23:</b>
     *
     * We can generalize the function above so that it's not specific to integers or addition, `zipWith`:
     *
@@ -503,6 +363,8 @@ object FunctionalDataStructuresSection extends FlatSpec with Matchers with org.s
   }
 
   /**
+    * <b>Exercise 3.24:</b>
+    *
     * As a final example for working with lists, let's implement a `hasSubsequence` function for checking whether a `List`
     * contains another `List` as a subsequence. For instance, `List(1, 2, 3, 4)` would have `List(1, 2)`, `List(2, 3)`
     * and `List(4)` as subsequences, among others:
@@ -537,22 +399,9 @@ object FunctionalDataStructuresSection extends FlatSpec with Matchers with org.s
   /**
     * = Trees =
     *
-    * List is just one example of what’s called an algebraic data type (ADT). An ADT is just a data type defined by one
-    * or more data constructors, each of which may contain zero or more arguments. We say that the data type is the sum
-    * or union of its data constructors, and each data constructor is the product of its arguments, hence the name
-    * algebraic data type.
+    * <b>Exercise 3.25:</b>
     *
-    * Algebraic data types can be used to define other data structures. Let’s define a simple binary tree data structure:
-    *
-    * {{{
-    *   sealed trait Tree[+A]
-    *   case class Leaf[A](value: A) extends Tree[A]
-    *   case class Branch[A](left: Tree[A], right: Tree[A]) extends Tree[A]
-    * }}}
-    *
-    * Pattern matching again provides a convenient way of operating over elements of our ADT. Let’s try writing a few
-    * functions. For starters, let's try to implement a function `size` to count the number of nodes (leaves and branches)
-    * in a tree:
+    * Let's try to implement a function `size` to count the number of nodes (leaves and branches) in a tree:
     */
 
   def treeSizeAssert(res0: Int, res1: Int): Unit = {
@@ -566,6 +415,8 @@ object FunctionalDataStructuresSection extends FlatSpec with Matchers with org.s
   }
 
   /**
+    * <b>Exercise 3.26:</b>
+    *
     * Following a similar implementation, we can write a function `maximum` that returns the maximum element in a
     * Tree[Int]:
     *
@@ -575,6 +426,8 @@ object FunctionalDataStructuresSection extends FlatSpec with Matchers with org.s
     *     case Branch(l,r) => maximum(l) max maximum(r)
     *   }
     * }}}
+    *
+    * <b>Exercise 3.27:</b>
     *
     * In the same fashion, let's implement a function `depth` that returns the maximum path length from the root of a
     * tree to any leaf.
@@ -590,25 +443,25 @@ object FunctionalDataStructuresSection extends FlatSpec with Matchers with org.s
   }
 
   /**
+    * <b>Exercise 3.28:</b>
+    *
     * We can also write a function `map`, analogous to the method of the same name on `List`, that modifies each element
-    * in a tree with a given function:
-    *
-    * {{{
-    *   def map[A,B](t: Tree[A])(f: A => B): Tree[B] = t match {
-    *     case Leaf(a) => Leaf(f(a))
-    *     case Branch(l,r) => Branch(map(l)(f), map(r)(f))
-    *   }
-    * }}}
-    *
-    * Let's try it out in the following exercise:
+    * in a tree with a given function. Let's try it out in the following exercise:
     */
 
   def treeMapAssert(res0: Branch[Int]): Unit = {
+    def map[A,B](t: Tree[A])(f: A => B): Tree[B] = t match {
+      case Leaf(a) => Leaf(f(a))
+      case Branch(l,r) => Branch(map(l)(f), map(r)(f))
+    }
+
     def t = Branch(Branch(Leaf(1), Leaf(2)), Leaf(3))
     Tree.map(t)(_ * 2) shouldBe res0
   }
 
   /**
+    * <b>Exercise 3.29:</b>
+    *
     * To wrap this section up, let's generalize `size`, `maximum`, `depth` and `map`, writing a new function `fold` that
     * abstracts over their similarities:
     *

--- a/src/main/scala/fpinscalalib/FunctionalParallelismSection.scala
+++ b/src/main/scala/fpinscalalib/FunctionalParallelismSection.scala
@@ -15,88 +15,14 @@ object FunctionalParallelismSection extends FlatSpec with Matchers with org.scal
     *
     * The following set of sections represent the exercises contained in the book "Functional Programming in Scala",
     * written by Paul Chiusano and Rúnar Bjarnason and published by Manning. This content library is meant to be used
-    * in tandem with the book, although excerpts of the theory needed to complete them have been added to guide you.
+    * in tandem with the book. We use the same numeration for the exercises for you to follow them.
     *
     * For more information about "Functional Programming in Scala" please visit its
     * <a href="https://www.manning.com/books/functional-programming-in-scala">official website</a>.
     *
     * = A data type for parallel computations =
     *
-    * Our main objective in this section is to be able to "create parallel computations". What does that mean exactly?
-    * Let’s try to refine this into something we can implement by examining a simple, parallelizable computation—summing
-    * a list of integers. The usual left fold for this would be as follows:
-    *
-    * {{{
-    *   def sum(ints: Seq[Int]): Int =
-    *     ints.foldLeft(0)((a,b) => a + b)
-    * }}}
-    *
-    * Instead of folding sequentially, we could use a divide-and-conquer algorithm; see the following listing.
-    *
-    * {{{
-    *   def sum(ints: IndexedSeq[Int]): Int =
-    *     if (ints.size <= 1)
-    *       ints.headOption getOrElse 0
-    *     else {
-    *       val (l, r) = ints.splitAt(ints.length / 2)
-    *       sum(l) + sum(r)
-    *     }
-    * }}}
-    *
-    * Using `IndexedSeq[Int]` instead of `Seq[Int]` gives us access to an efficient `splitAt` method for dividing the
-    * collection into two parts at a particular index. After dividing the sequence in half, we recursively sum both
-    * halves, and then combine their results. Unlike the `foldLeft`-based implementation, this one can be parallelized
-    * - the two halves can be summed in parallel.
-    *
-    * Looking at the `sum(l) + sum(r)`, which invokes `sum` on the two halves recursively, we can see that any data type
-    * we might choose to rep- resent our parallel computations needs to be able to `contain a result`. That result will
-    * have some meaningful type (in this case `Int`), and we require some way of extracting this result.
-    *
-    * For now, let's `invent` a container type for our result, `Par[A]` (for parallel), and legislate the existence of
-    * the functions we need:
-    *
-    * {{{
-    *   def unit[A](a: => A): Par[A]
-    *
-    *   def get[A](a: Par[A]): A
-    * }}}
-    *
-    * `unit` takes an unevaluated `A` and returns a computation that might evaluate it in a separate thread. We call it
-    * `unit` because in a sense it creates a unit of parallelism that just wraps a single value. `get` extracts the
-    * resulting value from a parallel computation. Let's update our example with our custom data type (and not worrying
-    * about the underlying implementation yet):
-    *
-    * {{{
-    *   def sum(ints: IndexedSeq[Int]): Int =
-    *     if (ints.size <= 1)
-    *       ints headOption getOrElse 0
-    *     else {
-    *       val (l, r) = ints.splitAt(ints.length / 2)
-    *       val sumL: Par[Int] = Par.unit(sum(l))
-    *       val sumR: Par[Int] = Par.unit(sum(r))
-    *       Par.get(sumL) + Par.get(sumR)
-    *     }
-    * }}}
-    *
-    * Note that we've wrapped the two recursive calls to `sum` in calls to `unit`, and we're calling `get` to extract
-    * the two results from the two subcomputations. Also, it's important to realize that `unit` simply returns a
-    * `Par[Int]` in this case, representing an asynchronous computation. But as soon as we pass that `Par` to `get`, we
-    * explicitly wait for it, generating a side effect. So it seems that we want to avoid calling `get`, or at least
-    * delay calling it until the very end. We want to be able to combine asynchronous computations without waiting for
-    * them to finish.
-    *
-    * If we don’t call `get`, that implies that our sum function must return a `Par[Int]`. Let's see how we can modify
-    * our implementation taking this into account:
-    *
-    * {{{
-    *   def sum(ints: IndexedSeq[Int]): Par[Int] =
-    *     if (ints.size <= 1)
-    *       Par.unit(ints.headOption getOrElse 0)
-    *     else {
-    *       val (l, r) = ints.splitAt(ints.length / 2)
-    *       Par.map2(sum(l), sum(r))(_ + _)
-    *     }
-    * }}}
+    * <b>Exercise 7.1:</b>
     *
     * `Par.map2` is a new higher-order function for combining the result of two parallel computations. Its signature is
     * as follows:
@@ -105,123 +31,24 @@ object FunctionalParallelismSection extends FlatSpec with Matchers with org.scal
     *    def map2[A,B,C](a: Par[A], b: Par[B])(f: (A,B) => C): Par[C]
     * }}}
     *
-    * = Explicit forking =
+    * = Refining the API =
     *
-    * Is it always the case that we want to evaluate the two arguments to `map2` in parallel? Probably not. Consider
-    * this simple hypothetical example:
+    * <b>Exercise 7.3:</b>
     *
-    * {{{
-    *   Par.map2(Par.unit(1), Par.unit(1))(_ + _)
-    * }}}
-    *
-    * In this case, we happen to know that the two computations we’re combining will execute so quickly that there isn’t
-    * much point in spawning off a separate logical thread to evaluate them. But our API doesn’t give us any way of
-    * providing this sort of information. That is, our current API is very inexplicit about when computations get forked
-    * off the main thread. We can do the forking more explicit by inventing a new function
-    * (`def fork[A](a: => Par[A]): Par[A]`), which we can take to mean that the given `Par` should be run in a separate
-    * logical thread:
+    * Let's fix the implementation of `map2` so that it respects the contract of timeouts on `Future`:
     *
     * {{{
-    *   def sum(ints: IndexedSeq[Int]): Par[Int] =
-    *     if (ints.length <= 1)
-    *       Par.unit(ints.headOption getOrElse 0)
-    *     else {
-    *       val (l, r) = ints.splitAt(ints.length / 2)
-    *       Par.map2(Par.fork(sum(l)), Par.fork(sum(r)))(_ + _)
+    *   def map2[A,B,C](a: Par[A], b: Par[B])(f: (A,B) => C): Par[C] =
+    *     es => {
+    *       val (af, bf) = (a(es), b(es))
+    *       Map2Future(af, bf, f)
     *     }
     * }}}
     *
-    * If `fork` simply holds on to its unevaluated argument until later, it requires no access to the mechanism for
-    * implementing parallelism. It just takes an unevaluated `Par` and “marks” it for concurrent evaluation. Let’s now
-    * assume this meaning for `fork`. With this model, `Par` itself doesn’t need to know how to actually implement the
-    * parallelism. It’s more a description of a parallel computation that gets interpreted at a later time by something
-    * like the `get` function. `Par` is no longer a `container` of a value that we could simply `get` when it becomes
-    * available. Now it's more of a first-class `program` that we can `run`. So let’s rename our `get` function to `run`,
-    * and dictate that this is where the parallelism actually gets implemented:
+    * <b>Exercise 7.4:</b>
     *
-    * {{{
-    *   def run[A](a: Par[A]): A
-    * }}}
-    *
-    * Because `Par` is now just a pure data structure, `run` has to have some means of implementing the parallelism,
-    * whether it spawns new threads, delegates tasks to a thread pool, or uses some other mechanism.
-    *
-    * = Picking a representation =
-    *
-    * Just by exploring this simple example and thinking through the consequences of different choices, we’ve sketched
-    * out the following API:
-    *
-    * {{{
-    *   // Creates a computation that immediately results in the value a:
-    *   def unit[A](a: A): Par[A]
-    *
-    *   // Combines the results of two parallel computations with a binary function:
-    *   def map2[A,B,C](a: Par[A], b: Par[B])(f: (A,B) => C): Par[C]
-    *
-    *   // Marks a computation for concurrent evaluation by run:
-    *   def fork[A](a: => Par[A]): Par[A]
-    *
-    *   // Wraps the expression a for concurrent evaluation by run:
-    *   def lazyUnit[A](a: => A): Par[A] = fork(unit(a))
-    *
-    *   // Fully evaluates a given Par, spawning parallel computations as requested by fork, and extracting the result:
-    *   def run[A](a: Par[A]): A
-    * }}}
-    *
-    * We know `run` needs to execute asynchronous tasks somehow. We could write our own low-level API, but there’s already
-    * a class that we can use in the Java Standard Library, `java.util.concurrent.ExecutorService`. `ExecutorService`
-    * lets us submit a `Callable` value (in Scala we’d probably just use a lazy argument to submit) and get back a
-    * corresponding `Future` that’s a handle to a computation that’s potentially running in a separate thread. We can
-    * obtain a value from a `Future` with its `get` method (which blocks the current thread until the value is available).
-    * Let’s try assuming that our `run` function has access to an `ExecutorService` and see if that suggests anything
-    * about the representation for `Par`:
-    *
-    * {{{
-    *   def run[A](s: ExecutorService)(a: Par[A]): A
-    * }}}
-    *
-    * The simplest possible model for `Par[A]` might be `ExecutorService => A.` This would obviously make `run` trivial
-    * to implement. But it might be nice to defer the decision of how long to wait for a computation, or whether to
-    * cancel it, to the caller of `run`. So `Par[A]` becomes `ExecutorService => Future[A]`, and `run` simply returns
-    * the `Future`:
-    *
-    * {{{
-    *   type Par[A] = ExecutorService => Future[A]
-    *
-    *   def run[A](s: ExecutorService)(a: Par[A]): Future[A] = a(s)
-    * }}}
-    *
-    * Let’s start implementing the functions of the API that we’ve developed so far. Now that we have a representation
-    * for `Par`, a first crack at it should be straightforward. What follows is a simplistic implementation using the
-    * representation of `Par` that we’ve chosen.
-    *
-    * {{{
-    *   object Par {
-    *     private case class UnitFuture[A](get: A) extends Future[A] {
-    *       def isDone = true
-    *       def get(timeout: Long, units: TimeUnit) = get
-    *       def isCancelled = false
-    *       def cancel(evenIfRunning: Boolean): Boolean = false
-    *     }
-    *
-    *     def unit[A](a: A): Par[A] = (es: ExecutorService) => UnitFuture(a)
-    *
-    *     def map2[A,B,C](a: Par[A], b: Par[B])(f: (A,B) => C): Par[C] =
-    *       (es: ExecutorService) => {
-    *         val af = a(es)
-    *         val bf = b(es)
-    *         UnitFuture(f(af.get, bf.get))
-    *      }
-    *
-    *      def fork[A](a: => Par[A]): Par[A] =
-    *        es => es.submit(new Callable[A] {
-    *          def call = a(es).get
-    *        })
-    *      }
-    * }}}
-    *
-    * This API already enables a rich set of operations. Here's a simple example: using `lazyUnit`, let's write a
-    * function to convert any function `A => B` to one that evaluates its result asynchronously:
+    * Let's create some operations! Using `lazyUnit`, let's write a function to convert any function `A => B` to one
+    * that evaluates its result asynchronously:
     */
 
   def parAsyncFAssert(res0: String): Unit = {
@@ -235,79 +62,23 @@ object FunctionalParallelismSection extends FlatSpec with Matchers with org.scal
   }
 
   /**
-    * Suppose we have a `Par[List[Int]]` representing a parallel computation that produces a `List[Int]`, and we’d like
-    * to convert this to a `Par[List[Int]]` whose result is sorted (without having to call `run`):
-    *
-    * {{{
-    *   def sortPar(parList: Par[List[Int]]): Par[List[Int]]
-    * }}}
-    *
-    * The only other combinator we have that allows us to manipulate the value of a `Par` in any way is `map2`. So if w
-    * passed `parList` to one side of `map2`, we’d be able to gain access to the `List` inside and sort it. And we can
-    * pass whatever we want to the other side of `map2`, so let’s just pass a no-op:
-    *
-    * {{{
-    *   def sortPar(parList: Par[List[Int]]): Par[List[Int]] =
-    *     map2(parList, unit(()))((a, _) => a.sorted)
-    * }}}
-    *
-    * We can generalize this further. We can “lift” any function of type `A => B` to become a function that takes
-    * `Par[A]` and returns `Par[B]`; we can map any function over a `Par`:
-    *
-    * {{{
-    *   def map[A,B](pa: Par[A])(f: A => B): Par[B] =
-    *     map2(pa, unit(()))((a,_) => f(a))
-    * }}}
-    *
-    * Let's try to implement `sortPar` via `map`. Remember that you can use the underscore notation to write anonymous
-    * functions:
-    **/
-  def parSortParAssert(res0: List[Int] => List[Int]): Unit = {
-    def sortPar(parList: Par[List[Int]]) = map(parList)(res0)
-
-    val executorService = Executors.newFixedThreadPool(2)
-    val parList = unit(List(1, 3, 2))
-    Par.run(executorService)(sortPar(parList)).get() shouldBe List(1, 2, 3)
-  }
-
-  /**
-    * What else can we implement using our API? Could we map over a list in parallel? Unlike `map2`, which combines two
-    * parallel computations, `parMap` (let’s call it) needs to combine N parallel computations. Let’s see how far we ca
-    * get implementing parMap in terms of existing combinators:
-    *
-    * {{{
-    *   def parMap[A,B](ps: List[A])(f: A => B): Par[List[B]] = {
-    *     val fbs: List[Par[B]] = ps.map(asyncF(f))
-    *     // ...
-    *   }
-    * }}}
+    * <b>Exercise 7.5:</b>
     *
     * Remember, `asyncF` converts an `A => B` to an `A => Par[B`] by forking a parallel computation to produce the
     * result. So we can fork off our N parallel computations pretty easily, but we need some way of collecting their
     * results. Are we stuck? Well, just from inspecting the types, we can see that we need some way of converting our
-    * `List[Par[B]]` to the `Par[List[B]]` required by the return type of `parMap`. Let's try to write the function
-    * `sequence` that will help us achieve that:
+    * `List[Par[B]]` to the `Par[List[B]]` required by the return type of `parMap`.
+    *
+    * Let's try to write the function `sequence` that will allow us convert a `List[Par[B]]` into a `Par[List[B]]`:
     *
     * {{{
     *   def sequence_simple[A](l: List[Par[A]]): Par[List[A]] =
     *     l.foldRight[Par[List[A]]](unit(List()))((h,t) => map2(h,t)(_ :: _))
     * }}}
     *
-    * Once we have `sequence`, we can complete our implementation of `parMap`:
+    * <b>Exercise 7.6:</b>
     *
-    * {{{
-    *   def parMap[A,B](ps: List[A])(f: A => B): Par[List[B]] = fork {
-    *     val fbs: List[Par[B]] = ps.map(asyncF(f))
-    *     sequence(fbs)
-    *   }
-    * }}}
-    *
-    * Note that we’ve wrapped our implementation in a call to `fork`. With this implementation, `parMap` will return
-    * immediately, even for a huge input list. When we later call run, it will fork a single asynchronous computation
-    * which itself spawns N parallel computations, and then waits for these computations to finish,
-    * collecting their results into a list.
-    *
-    * We can also implement `parFilter`, a function which filters elements of a list in parallel:
+    * We can also implement `parFilter`, a function that filters elements of a list in parallel:
     *
     * {{{
     *   def parFilter[A](l: List[A])(f: A => Boolean): Par[List[A]] = {
@@ -331,122 +102,22 @@ object FunctionalParallelismSection extends FlatSpec with Matchers with org.scal
       result shouldBe res0
   }
 
-   /** = The algebra of an API =
+   /**
+    * = The algebra of an API =
     *
-    * Like any design choice, choosing laws has consequences — it places constraints on what the operations can mean,
-    * determines what implementation choices are possible, and affects what other properties can be true. Let’s look at
-    * an example. We’ll just make up a possible law that seems reasonable. This might be used as a test case if we were
-    * writing tests for our library:
-    */
-
-  def parLawMappingAssert(res0: Int) = {
-    val lawLeftSide = map(unit(1))(_ + 1)
-    val executorService = Executors.newFixedThreadPool(2)
-    Par.run(executorService)(lawLeftSide).get() shouldBe Par.run(executorService)(unit(res0)).get()
-  }
-
-  /**
-    * We’re saying that mapping over `unit(1)` with the `_ + 1` function is in some sense equivalent to `unit(2)`.
-    * For now, let’s say two `Par` objects are equivalent if for any valid `ExecutorService` argument, their `Future`
-    * results have the same value. We can check that this holds for a particular ExecutorService with a function like
-    * this:
-    */
-
-  def parEqualAssert(res0: Boolean) = {
-    def equal[A](e: ExecutorService)(p: Par[A], p2: Par[A]): Boolean = p(e).get == p2(e).get
-
-    val lawLeftSide = map(unit(1))(_ + 1)
-    val executorService = Executors.newFixedThreadPool(2)
-    equal(executorService)(lawLeftSide, unit(2)) shouldBe res0
-  }
-
-  /**
-    * The preceding could be generalized this way:
+    * <b>Exercise 7.9</b>
     *
-    * {{{
-    *   map(unit(x))(f) == unit(f(x))
-    * }}}
-    *
-    * Here we’re saying this should hold for any choice of `x` and `f`, not just `1` and the `_ + 1` function. This
-    * places some constraints on our implementation. Our implementation of unit can’t, say, inspect the value it receives
-    * and decide to return a parallel computation with a result of `42` when the input is `1` — it can only pass along
-    * whatever it receives.
-    *
-    * Let’s see if we can simplify this law further. We said we wanted this law to hold for any choice of `x` and `f`.
-    * Something interesting happens if we substitute the identity function for `f`. We can simplify both sides of the
-    * equation and get a new law that’s considerably simpler:
-    *
-    * {{{
-    *   map(unit(x))(f) == unit(f(x))
-    *   map(unit(x))(id) == unit(id(x))
-    *   map(unit(x))(id) == unit(x)
-    *   map(y)(id) == y
-    * }}}
-    *
-    * Let’s consider a stronger property — that `fork` should not affect the result of a parallel computation:
-    *
-    * {{{
-    *   fork(x) == x
-    * }}}
-    *
-    * Surprisingly, this simple property places strong constraints on our implementation of `fork`. After you’ve written
-    * down a law like this, take off your implementer hat, put on your debugger hat, and try to break your law. We’re
-    * expecting that `fork(x) == x` for all choices of `x`, and any choice of `ExecutorService`. We have a good sense of
-    * what `x` could be — it’s some expression making use of `fork`, `unit`, and `map2` (and other combinators derived
-    * from these). What about `ExecutorService`? There’s actually a rather subtle problem that will occur in most
-    * implementations of `fork`. When using an `ExecutorService` backed by a thread pool of bounded size (see
-    * `Executors.newFixedThreadPool`), it’s very easy to run into a deadlock.
-    *
-    * Can we fix `fork` to work on fixed-size thread pools? Let’s look at a different implementation:
-    *
-    * {{{
-    *   def fork[A](fa: => Par[A]): Par[A] = es => fa(es)
-    * }}}
-    *
-    * This certainly avoids deadlock. The only problem is that we aren’t actually forking a separate logical thread to
-    * evaluate `fa`. So `fork(hugeComputation)(es)` for some `ExecutorService` `es`, would run `hugeComputation` in the
-    * main thread, which is exactly what we wanted to avoid by calling `fork`. This is still a useful combinator,
-    * though, since it lets us delay instantiation of a computation until it’s actually needed. Let’s give it a name,
-    * `delay`:
-    *
-    * {{{
-    *   def delay[A](fa: => Par[A]): Par[A] = es => fa(es)
-    * }}}
-    *
-    * But we’d really like to be able to run arbitrary computations over fixed-size thread pools. In order to do that,
-    * we’ll need to pick a different representation of `Par`.
+    * For a thread pool of size 2, `fork(fork(fork(x)))` will deadlock, and so on. Another, perhaps more interesting
+    * example is `fork(map2(fork(x), fork(y)))`. In this case, the outer task is submitted first and occupies a thread
+    * waiting for both `fork(x)` and `fork(y)`. The `fork(x)` and `fork(y)` tasks are submitted and run in parallel,
+    * except that only one thread is available, resulting in deadlock.
     *
     * = Refining combinators to their most general form =
     *
-    * Functional design is an iterative process. After you write down your API and have at least a prototype
-    * implementation, try using it for progressively more complex or realistic scenarios. Sometimes you’ll find that
-    * these scenarios require new combinators. But before jumping right to implementation, it’s a good idea to see if
-    * you can refine the combinator you need to its most general form. It may be that what you need is just a specific
-    * case of some more general combinator.
+    * <b>Exercise 7.11</b>
     *
-    * Let’s look at an example of this. Suppose we want a function to choose between two forking computations based on
-    * the result of an initial computation:
-    *
-    * {{{
-    *   def choice[A](cond: Par[Boolean])(t: Par[A], f: Par[A]): Par[A]
-    * }}}
-    *
-    * This constructs a computation that proceeds with `t` if `cond` results in `true`, or `f` if `cond` results in
-    * `false`. We can certainly implement this by blocking on the result of the `cond`, and then using this result to
-    * determine whether to run `t` or `f`. Here’s a simple blocking implementation:
-    *
-    * {{{
-    *   def choice[A](cond: Par[Boolean])(t: Par[A], f: Par[A]): Par[A] =
-    *     es =>
-    *       // Notice we are blocking on the result of cond:
-    *       if (run(es)(cond).get) t(es)
-    *       else f(es)
-    * }}}
-    *
-    * Let’s see if we can think of some variations to get at the essence of this combinator. There’s something rather
-    * arbitrary about the use of Boolean here, and the fact that we’re only selecting among two possible parallel
-    * computations, `t` and `f`. Why just two? If it’s useful to be able to choose between two parallel computations
-    * based on the results of a first, it should be certainly be useful to choose between N computations:
+    * Let’s implement `choiceN`, that will allow us to choose between an arbitrary list of parallel computations based
+    * on the result of a given first:
     *
     * {{{
     *   def choiceN[A](n: Par[Int])(choices: List[Par[A]]): Par[A] =
@@ -467,9 +138,9 @@ object FunctionalParallelismSection extends FlatSpec with Matchers with org.scal
     choice.apply(executorService).get() shouldBe 1
   }
   /**
-    * There’s still something rather arbitrary about `choiceN`. The choice of `List` seems overly specific. Why does it
-    * matter what sort of container we have? For instance, what if, instead of a list of computations, we have a `Map`
-    * of them:
+    * <b>Exercise 7.12:</b>
+    *
+    * Instead of a list of computations, let's use a `Map` of them:
     */
 
   def parChoiceMapAssert(res0: Int): Unit = {
@@ -486,7 +157,9 @@ object FunctionalParallelismSection extends FlatSpec with Matchers with org.scal
   }
 
   /**
-    * Let’s make a more general signature that unifies them all:
+    * <b>Exercise 7.13:</b>
+    *
+    * Let’s make a more general function that unifies them all:
     */
 
   def parChooserAssert(res0: String): Unit = {
@@ -506,7 +179,7 @@ object FunctionalParallelismSection extends FlatSpec with Matchers with org.scal
   }
 
   /**
-    * This primitive `chooser` is usually called `bind` or `flatMap`. Let's use it to re-implement `choice`:
+    * This new primitive `chooser` is usually called `bind` or `flatMap`. Let's use it to re-implement `choice`:
     */
 
   def parChoiceViaFlatMapAssert(res0: String): Unit = {
@@ -532,11 +205,9 @@ object FunctionalParallelismSection extends FlatSpec with Matchers with org.scal
   }
 
   /**
-    * Is `flatMap` really the most primitive possible function, or can we generalize further? Let’s play around with it
-    * a bit more. The name `flatMap` is suggestive of the fact that this operation could be decomposed into two steps:
-    * mapping `f: A => Par[B]` over our `Par[A]`, which generates a `Par[Par[B]]`, and then flattening this nested
-    * `Par[Par[B]]` to a `Par[B]`. But this is interesting — it suggests that all we needed to do was add an even simpler
-    * combinator, let’s call it `join`, for converting a Par[Par[X]] to Par[X] for any choice of X:
+    * <b>Exercise 7.14:</b>
+    *
+    * `join` is a simpler combinator, for converting a Par[Par[X]] to Par[X] for any choice of X:
     *
     * {{{
     *   def join[A](a: Par[Par[A]]): Par[A] =

--- a/src/main/scala/fpinscalalib/FunctionalStateSection.scala
+++ b/src/main/scala/fpinscalalib/FunctionalStateSection.scala
@@ -15,94 +15,14 @@ object FunctionalStateSection extends FlatSpec with Matchers with org.scalaexerc
     *
     * The following set of sections represent the exercises contained in the book "Functional Programming in Scala",
     * written by Paul Chiusano and Rúnar Bjarnason and published by Manning. This content library is meant to be used
-    * in tandem with the book, although excerpts of the theory needed to complete them have been added to guide you.
+    * in tandem with the book. We use the same numeration for the exercises for you to follow them.
     *
     * For more information about "Functional Programming in Scala" please visit its
     * <a href="https://www.manning.com/books/functional-programming-in-scala">official website</a>.
     *
     * = Purely functional random number generation =
     *
-    * If you need to generate random numbers in Scala, there’s a class in the standard library, `scala.util.Random`,
-    * with a pretty typical imperative API that relies on side effects. Here’s an example of its use:
-    *
-    * {{{
-    *   val rng = new scala.util.Random
-    *
-    *   scala> rng.nextDouble
-    *   res1: Double = 0.9867076608154569
-    *   scala> rng.nextDouble
-    *   res2: Double = 0.8455696498024141
-    * }}}
-    *
-    * As this API doesn't guarantee referential transparency, we need to make the state updates `explicit`. Here's one
-    * possible interface to a random number generator:
-    *
-    * {{{
-    *   trait RNG {
-    *     def nextInt: (Int, RNG)
-    *   }
-    * }}}
-    *
-    * The following is a simple random number generator that uses the same algorithm as `scala.util.Random`. The details
-    * of this implementation aren’t really important, but notice that `nextInt` returns both the generated value and a
-    * new `RNG` to use for generating the next value.
-    *
-    * {{{
-    *   case class Simple(seed: Long) extends RNG {
-    *     def nextInt: (Int, RNG) = {
-    *       // `&` is bitwise AND. We use the current seed to generate a new seed.
-    *       val newSeed = (seed * 0x5DEECE66DL + 0xBL) & 0xFFFFFFFFFFFFL
-    *       // The next state, which is an `RNG` instance created from the new seed.
-    *       val nextRNG = Simple(newSeed)
-    *       // `>>>` is right binary shift with zero fill. The value `n` is our new pseudo-random integer.
-    *       val n = (newSeed >>> 16).toInt
-    *       // The return value is a tuple containing both a pseudo-random integer and the next `RNG` state.
-    *       (n, nextRNG)
-    *       }
-    *    }
-    * }}}
-    *
-    * Here's an example of using this API from the interpreter:
-    *
-    * {{{
-    *   scala> val rng = SimpleRNG(42)
-    *   rng: SimpleRNG = SimpleRNG(42)
-    *
-    *   scala> val (n1, rng2) = rng.nextInt
-    *   n1: Int = 16159453
-    *   rng2: RNG = SimpleRNG(1059025964525)
-    *
-    *   scala> val (n2, rng3) = rng2.nextInt
-    *   n2: Int = -1281479697
-    *   rng3: RNG = SimpleRNG(197491923327988)
-    * }}}
-    *
-    * We can run this sequence of statements as many times as we want and we’ll always get the same values. When
-    * we call `rng.nextInt`, it will always return `16159453` and a new `RNG`, whose `nextInt` will always return
-    * `-1281479697`. In other words, this API is pure.
-    *
-    * = Making stateful APIs pure =
-    *
-    * Making seemingly stateful APIs pure is a problem that comes up frequently. We can always handle this in the same
-    * way, for instance:
-    *
-    * {{{
-    *   class Foo {
-    *     private var s: FooState = ...
-    *     def bar: Bar
-    *     def baz: Int
-    *   }
-    * }}}
-    *
-    * Supposing `bar` and `baz` each mutate `s` in some way, we can translate this to the following alternative `trait`,
-    * making the caller responsible for passing the computed next state through the rest of the program:
-    *
-    * {{{
-    *   trait Foo {
-    *     def bar: (Bar, Foo)
-    *     def baz: (Int, Foo)
-    *   }
-    * }}}
+    * <b>Exercise 6.1:</b>
     *
     * Let's write a function that uses `RNG.nextInt` to generate a random integer between `0` and `Int.maxValue`, making
     * sure to handle the corner case when `nextInt` returns `Int.MinValue`, which doesn't have a non-negative
@@ -125,7 +45,9 @@ object FunctionalStateSection extends FlatSpec with Matchers with org.scalaexerc
   }
 
   /**
-    * Now let's write a function to generate a `Double` between `0` and `1`, not including `1`. Note the use of
+    * <b>Exercise 6.2:</b>
+    *
+    * Now let's write a function to generate a `Double` between `0` and `1`, excluding `1`. Note that we use
     * `Int.MaxValue` to divide a random positive integer:
     */
 
@@ -145,12 +67,13 @@ object FunctionalStateSection extends FlatSpec with Matchers with org.scalaexerc
   }
 
   /**
+    * <b>Exercise 6.3:</b>
+    *
     * Following the same principle, we're going to write functions that generate tuples of random values, i.e.: an
     * `(Int, Double)` pair, a `(Double, Int)` pair, and a `(Double, Double, Double)` 3-tuple, by reusing the functions
     * we've already written:
     *
     * {{{
-    *
     *   def intDouble(rng: RNG): ((Int, Double), RNG) = {
     *     val (i, r1) = rng.nextInt
     *     val (d, r2) = double(r1)
@@ -169,6 +92,8 @@ object FunctionalStateSection extends FlatSpec with Matchers with org.scalaexerc
     *     ((d1, d2, d3), r3)
     *   }
     * }}}
+    *
+    * <b>Exercise 6.4:</b>
     *
     * We can even go a bit beyond and write a function to generate a list of random integers:
     */
@@ -190,56 +115,11 @@ object FunctionalStateSection extends FlatSpec with Matchers with org.scalaexerc
   }
 
   /**
-    * To simplify the pattern we've been seeing so far, and to avoid passing the state along each time we execute these
-    * state actions, let's make a type alias for the `RNG` state action data type:
+    * = A better API for state actions =
     *
-    * {{{
-    *   type Rand[+A] = RNG => (A, RNG)
-    * }}}
+    * <b>Exercise 6.5:</b>
     *
-    * We can now turn methods such as `RNG`'s `nextInt` into values of this new type:
-    *
-    * {{{
-    *   val int: Rand[Int] = _.nextInt
-    * }}}
-    *
-    * We want to write combinators that let us combine `Rand` actions while avoiding explicitly passing along the `RNG`
-    * state. We’ll end up with a kind of domain-specific language that does all of the passing for us. For example, a
-    * simple `RNG` state transition is the `unit` action, which passes the `RNG` state through without using it, always
-    * returning a constant value rather than a random value:
-    *
-    * {{{
-    *   def unit[A](a: A): Rand[A] = rng => (a, rng)
-    * }}}
-    *
-    * There’s also `map` for transforming the output of a state action without modifying the state itself. Remember,
-    * `Rand[A]` is just a type alias for a function type `RNG => (A, RNG)`, so this is just a kind of function
-    * composition:
-    *
-    * {{{
-    *   def map[A,B](s: Rand[A])(f: A => B): Rand[B] = rng => {
-    *     val (a, rng2) = s(rng)
-    *     (f(a), rng2)
-    *   }
-    * }}}
-    *
-    * As an example of how `map` is used, let’s write `nonNegativeEven`, which reuses `nonNegative Int` to generate an
-    * `Int` that’s greater than or equal to zero and divisible by two:
-    */
-
-  def randomNonNegativeEvenAssert(res0: Int): Unit = {
-    def nonNegativeEven: Rand[Int] = map(nonNegativeInt)(i => i - i % res0)
-
-    val (result1, rng1) = nonNegativeEven(Simple(47))
-    val result2 = nonNegativeEven(rng1)._1
-
-    result1 % 2 shouldBe 0
-    result2 % 2 shouldBe 0
-    result1 should not be result2
-  }
-
-  /**
-    * We can also use `map` to reimplement `double` in a more elegant way:
+    * Let's use `map` to reimplement `double` in a more elegant way:
     */
 
   def randomDoubleViaMap(res0: Int): Unit = {
@@ -256,9 +136,10 @@ object FunctionalStateSection extends FlatSpec with Matchers with org.scalaexerc
   }
 
   /**
-    * Now we're going to implement `map2`, that will allow us to implement functions like `intDouble` and `doubleInt`.
-    * This function takes two actions, `ra` and `rb`, and a binary function `f` for combining their results, and returns
-    * a new action that combines them:
+    * <b>Exercise 6.6:</b>
+    *
+    * Now we're going to implement `map2` which takes two actions, `ra` and `rb`, and a binary function `f` for combining
+    * their results, and returns a new action that combines them:
     *
     * {{{
     *   def map2[A,B,C](ra: Rand[A], rb: Rand[B])(f: (A, B) => C): Rand[C] =
@@ -269,20 +150,7 @@ object FunctionalStateSection extends FlatSpec with Matchers with org.scalaexerc
     *     }
     * }}}
     *
-    * If we have an action that generates values of type `A` and an action to generate values of type `B`, then we can
-    * combine them into one action that generates pairs of both `A` and `B`:
-    *
-    * {{{
-    *   def both[A,B](ra: Rand[A], rb: Rand[B]): Rand[(A,B)] = map2(ra, rb)((_, _))
-    * }}}
-    *
-    * We can use this to reimplement `intDouble` and `doubleInt` from exercise 6.3 more succinctly:
-    *
-    * {{{
-    *   val randIntDouble: Rand[(Int, Double)] = both(int, double)
-    *
-    *   val randDoubleInt: Rand[(Double, Int)] = both(double, int)
-    * }}}
+    * <b>Exercise 6.7:</b>
     *
     * If we can combine two `RNG` transitions, we should be able to combine a whole list of them. Let's implement
     * `sequence` for combining a `List` of transitions into a single transition:
@@ -292,13 +160,7 @@ object FunctionalStateSection extends FlatSpec with Matchers with org.scalaexerc
     *     fs.foldRight(unit(List[A]()))((f, acc) => map2(f, acc)(_ :: _))
     * }}}
     *
-    * We can use `sequence` to reimplement the `ints` function we wrote before. To do so, let's use the standard library
-    * function `List.fill(n)(x)` to make a list with `x` repeated `n` times:
-    *
-    * {{{
-    *   def _ints(count: Int): Rand[List[Int]] =
-    *     sequence(List.fill(count)(int))
-    * }}}
+    * <b>Exercise 6.8:</b>
     *
     * Our next step is to implement `flatMap`, as it will allow us to change state operations:
     *
@@ -333,8 +195,9 @@ object FunctionalStateSection extends FlatSpec with Matchers with org.scalaexerc
   }
 
   /**
-    * We can also rewrite `map` and `map2` in terms of `flatMap`. The fact that this is possible is why we say that
-    * `flatMap` is more powerful than `map` and `map2`.
+    * <b>Exercise 6.10:</b>
+    *
+    * We can also rewrite `map` and `map2` in terms of `flatMap`:
     *
     * {{{
     *   def _map[A,B](s: Rand[A])(f: A => B): Rand[B] =
@@ -342,6 +205,8 @@ object FunctionalStateSection extends FlatSpec with Matchers with org.scalaexerc
     *    def _map2[A,B,C](ra: Rand[A], rb: Rand[B])(f: (A, B) => C): Rand[C] =
     *     flatMap(ra)(a => map(rb)(b => f(a, b)))
     * }}}
+    *
+    * <b>Exercise 6.x:</b>
     *
     * As a final example, let’s revisit the functions we previously wrote and implement a function that will roll a
     * six-sided die:
@@ -364,29 +229,11 @@ object FunctionalStateSection extends FlatSpec with Matchers with org.scalaexerc
   import fpinscalalib.customlib.state.State._
 
   /**
-    * The functions we’ve just written — `unit`, `map`, `map2`, `flatMap`, and `sequence` — aren’t really specific to
-    * random number generation at all. They’re general-purpose functions for working with state actions, and don’t care
-    * about the type of the state. For instance, we can give `map` a more general signature:
+    * = A general state action data type =
     *
-    * {{{
-    *   def map[S,A,B](a: S => (A,S))(f: A => B): S => (B,S)
-    * }}}
+    * <b>Exercise 6.10:</b>
     *
-    * This new version of `map` still retains the same implementation. We should then come up with a more general type
-    * than `Rand`, for handling any type of state:
-    *
-    * {{{
-    *   case class State[S,+A](run: S => (A,S))
-    * }}}
-    *
-    * Now we have a single, general-purpose type and can use it to write general-purpose functions for capturing common
-    * patterns of stateful programs. We can now  make `Rand` a type alias for `State`:
-    *
-    * {{{
-    *   type Rand[A] = State[RNG, A]
-    * }}}
-    *
-    * We can also generalize the functions `unit`, `map`, `map2`, `flatMap` and `sequence`:
+    * Let's generalize the functions `unit`, `map`, `map2`, `flatMap` and `sequence`:
     *
     * {{{
     *   def unit[S, A](a: A): State[S, A] = State(s => (a, s))
@@ -405,8 +252,10 @@ object FunctionalStateSection extends FlatSpec with Matchers with org.scalaexerc
     *     sas.foldRight(unit[S, List[A]](List()))((f, acc) => f.map2(acc)(_ :: _))
     * }}}
     *
+    * <b>Exercise 6.11:</b>
+    *
     * As a final showcase of the uses of `State`, let's implement a finite state automaton that models a simple candy
-    * dispenser. The machine has two types of input: you can insert a coin, or you can turn the knob to dispense candy.
+    * dispenser. The machine has two inputs: you can insert a coin, or you can dispense candy by turning the knob.
     * It can be in one of two states: locked or unlocked. It also tracks how many candies are left and how many coins
     * it contains.
     *
@@ -417,16 +266,16 @@ object FunctionalStateSection extends FlatSpec with Matchers with org.scalaexerc
     *   case class Machine(locked: Boolean, candies: Int, coins: Int)
     * }}}
     *
-    * The rules of the machine are as follows:
+    * The rules of the machine are:
     *
-    * - Inserting a coin into a locked machine will cause it to unlock if there’s any candy left.
-    * - Turning the knob on an unlocked machine will cause it to dispense candy and then lock.
-    * - Turning the knob on a locked machine or inserting a coin into an unlocked machine does nothing.
-    * - A machine that’s out of candy ignores all inputs.
+    * - Inserting a coin into a locked machine will unlock it if there’s still any candy left.
+    * - Turning the knob on an unlocked machine will cause it to dispense one candy and return to a locked state.
+    * - Turning the knob on a locked machine or inserting a coin into an unlocked machine has no effect.
+    * - A machine that’s out of candy ignores any kind of input.
     *
-    * The method `simulateMachine` should operate the machine based on the list of inputs and return the number of coins
-    * and candies left in the machine at the end. For example, if the input `Machine` has 10 coins and 5 candies, and a
-    * total of 4 candies are successfully bought, the output should be `(14, 1)`.
+    * The method `simulateMachine` should operate the machine based on a list of inputs and return the number of coins
+    * and candies left in the machine. For instance, if the input `Machine` has 10 coins and 5 candies, and a
+    * total of 4 candies are bought successfully, the output should be `(14, 1)`.
     */
 
   def candyMachineAssert(res0: Int, res1: Int): Unit = {

--- a/src/main/scala/fpinscalalib/GettingStartedWithFPSection.scala
+++ b/src/main/scala/fpinscalalib/GettingStartedWithFPSection.scala
@@ -11,54 +11,14 @@ object GettingStartedWithFPSection extends FlatSpec with Matchers with org.scala
     *
     * The following set of sections represent the exercises contained in the book "Functional Programming in Scala",
     * written by Paul Chiusano and Rúnar Bjarnason and published by Manning. This content library is meant to be used
-    * in tandem with the book, although excerpts of the theory needed to complete them have been added to guide you.
+    * in tandem with the book. We use the same numeration for the exercises for you to follow them.
     *
     * For more information about "Functional Programming in Scala" please visit its
     * <a href="https://www.manning.com/books/functional-programming-in-scala">official website</a>.
     *
     * = Tail-recursive functions =
     *
-    * We're going to introduce some of the basic techniques for writing functional programs. Let's start by writing
-    * loops using tail-recursive functions. For instance, let's take a look at how to functionally write a function that
-    * calculates the factorial of a given number.
-    *
-    * {{{
-    * def factorial(n: Int): Int = {
-    * @annotation.tailrec
-    * def go(n: Int, acc: Int): Int =
-    *   if (n <= 0) acc
-    *   else go(n - 1, n * acc)
-    *   go(n, 1)
-    * }
-    * }}}
-    *
-    * In this example, we’re defining a recursive helper function inside the body of the functional function. We often
-    * refer these helper functions as `go` or `loop`. Since it’s local the `go` function can only be referred to from
-    * within the body of the factorial function, just like a local variable would.
-    *
-    * The arguments to `go` are the state for the loop. In this case, they're the remaining value `n` and the current
-    * accumulated factorial `acc`. To advance to the next iteration, we simply call `go` recursively with the new loop
-    * state: `go(n-1, n*acc)`, and to exit from the loop we return a value without a recursive call (in this case, we
-    * return the value of `acc` if `n <= 0`).
-    *
-    * Scala can detect this sort of self-recursion and compiles it to the same sort of bytecode as would be emitted
-    * by a `while` loop, as long as the recursive call is in tail position. The basic idea is that this optimization
-    * (tail call elimination) is applied when there's no additional work left to do after the recursive call returns.
-    *
-    * Let's do the same with a function to call the nth number from the Fibonacci sequence. The first two numbers
-    * are 0 and 1. Then, the nth number is always the sum of the previous two, i.e.: 0, 1, 1, 2, 3, 5... The fib`
-    * function starts by calling its `loop` helper function with the initial values of `n` (the position in the sequence
-    * we need to calculate), and the previous and current values in the sequence.
-    *
-    * {{{
-    *   def fib(n: Int): Int = {
-    *   @annotation.tailrec
-    *   def loop(n: Int, prev: Int, cur: Int): Int =
-    *     if (n <= ???) prev
-    *     else loop(n - ???, cur, prev + cur)
-    *   loop(n, 0, 1)
-    * }
-    * }}}
+    * <b>Exercise 2.1</b>:
     *
     * Try to fix the `loop` function inside `fib` so that it returns the correct values for each case in a tail-recursive
     * way. What should the missing expressions for the trivial case and the recursive call be?
@@ -77,68 +37,11 @@ object GettingStartedWithFPSection extends FlatSpec with Matchers with org.scala
   }
 
   /**
-    * = Polymorphic and higher-order functions =
-    *
-    * Polymorphic functions allow us to write code that works for any type it's given. For example, take a look at
-    * `findFirst`, a function that finds the first index in an array where the key occurs (or `-1` if it doesn't exist),
-    * implemented more generally by accepting a function to use for testing a particular `A` value.
-    *
-    * {{{
-    *   def findFirst[A](as: Array[A], p: A => Boolean): Int = {
-    *     @annotation.tailrec
-    *     def loop(n: Int): Int =
-    *       if (n >= as.length) -1
-    *       // If the function `p` matches the current element,
-    *       // we've found a match and we return its index in the array.
-    *       else if (p(as(n))) n
-    *       else loop(n + 1)
-    *
-    *     loop(0)
-    *   }
-    * }}}
-    *
-    * To write a polymorphic function as a method, we introduce a comma-separated list of type parameters, surrounded by
-    * square brackets (here, just a single `[A]`), following the name of the function, in this case `findFirst`.
-    *
     * = Higher-order functions =
     *
-    * Let's see an example of a higher-order function (HOF):
-    * {{{
-    *   def formatResult(name: String, n: Int, f: Int => Int) = {
-    *     val msg = "The %s of %d is %d."
-    *     msg.format(name, n, f(n))
-    *   }
-    * }}}
+    * <b>Exercise 2.2</b>:
     *
-    * Our `formatResult` HOF takes another function called `f`. We give a type to `f`, as we would for any other parameter.
-    * Its type is `Int => Int`, which indicates that `f` expects an integer argument and will also return an integer.
-    *
-    * Let's create a polymorphic, tail-recursive higher-order function that checks if an array is sorted, according to
-    * a given comparison function that will be passed as a parameter:
-    *
-    * {{{
-    *   def isSorted[A](as: Array[A], ordering: (A, A) => Boolean): Boolean = {
-    *     @annotation.tailrec
-    *     def go(n: Int): Boolean =
-    *       if (n >= as.length - 1) true
-    *       else if (ordering(as(n), as(n + 1))) false
-    *       else go(n + 1)
-    *
-    *     go(0)
-    *    }
-    * }}}
-    *
-    * When using HOFs, it's convenient to be able to call these functions with anonymous functions, rather than
-    * having to supply an existing named function. For instance, using the previously implemented `findFirst`:
-    *
-    * {{{
-    *   findFirst(Array(7, 9, 13), (x: Int) => x == 9)
-    * }}}
-    *
-    * The syntax `(x: Int) => x == 9` is a `function literal` or `anonymous function`, defining a function that takes one
-    * argument `x` of type `Int` and returns a `Boolean` indicating whether `x` is equal to 9.
-    *
-    * Let's do the same with `isSorted`. After taking a detailed look at its implementation, what would be the results of
+    * Let's do the same with `isSorted`. Take a detailed look at its implementation, what would be the results of
     * applying the following anonymous functions to it?
     */
 
@@ -159,16 +62,11 @@ object GettingStartedWithFPSection extends FlatSpec with Matchers with org.scala
   }
 
   /**
+    * <b>Exercise 2.3</b>:
+    *
     * Currying is a transformation which converts a function `f` of two arguments into a function of one argument that
     * partially applies `f`. Taking into account its signature, there's only one possible implementation that compiles.
-    * Take a look at it:
-    *
-    * {{{
-    *   def curry[A,B,C](f: (A, B) => C): A => (B => C) =
-    *     a => b => f(a, b)
-    * }}}
-    *
-    * Let's verify if this principle holds true in the following exercise:
+    * Take a look at its implementation and verify if this principle holds true in the following exercise:
     */
   def curryAssert(res0: Boolean, res1: Boolean): Unit = {
     def curry[A,B,C](f: (A, B) => C): A => (B => C) =
@@ -183,13 +81,10 @@ object GettingStartedWithFPSection extends FlatSpec with Matchers with org.scala
   }
 
   /**
-    * Uncurrying is the reverse transformation of curry. Take a look at its straightforward implementation:
-    * {{{
-    *   def uncurry[A,B,C](f: A => B => C): (A, B) => C =
-    *     (a, b) => f(a)(b)
-    * }}}
+    * <b>Exercise 2.4</b>:
     *
-    * In this next exercise, check to see if this principle holds true:
+    * Let's do the same with uncurrying is the reverse transformation of curry. Take a look at its implementation and
+    * check to see if this principle holds true:
     */
   def uncurryAssert(res0: Boolean, res1: Boolean): Unit = {
     def uncurry[A,B,C](f: A => B => C): (A, B) => C =
@@ -203,15 +98,10 @@ object GettingStartedWithFPSection extends FlatSpec with Matchers with org.scala
   }
 
   /**
-    * Function composition can be implemented in the same fashion, just by following the types of its signature. In this
-    * case we want to feed the output of one function to the input of another function.
+    * <b>Exercise 2.5</b>:
     *
-    * {{{
-    *   def compose[A,B,C](f: B => C, g: A => B): A => C =
-    *     a => f(g(a))
-    * }}}
-    *
-    * Finally, let's check how this `compose` function behaves in the following exercise:
+    * Function composing feeds the output of one function to the input of another function. Look at the implementation
+    * of `compose` and test its behavior on this exercise:
     */
   def composeAssert(res0: Boolean, res1: Int, res2: Int): Unit = {
     def compose[A,B,C](f: B => C, g: A => B): A => C =

--- a/src/main/scala/fpinscalalib/StrictnessAndLazinessSection.scala
+++ b/src/main/scala/fpinscalalib/StrictnessAndLazinessSection.scala
@@ -15,142 +15,14 @@ object StrictnessAndLazinessSection extends FlatSpec with Matchers with org.scal
     *
     * The following set of sections represent the exercises contained in the book "Functional Programming in Scala",
     * written by Paul Chiusano and Rúnar Bjarnason and published by Manning. This content library is meant to be used
-    * in tandem with the book, although excerpts of the theory needed to complete them have been added to guide you.
+    * in tandem with the book. We use the same numeration for the exercises for you to follow them.
     *
     * For more information about "Functional Programming in Scala" please visit its
     * <a href="https://www.manning.com/books/functional-programming-in-scala">official website</a>.
     *
     * = Strict and non-strict functions =
     *
-    * Non-strictness is a property of a function. To say a function is `non-strict` just means that the function may
-    * choose not to evaluate one or more of its arguments. In contrast, a `strict` function always evaluates its
-    * arguments.  Unless we tell it otherwise, any function definition in Scala will be strict. As an example, consider
-    * the following function:
-    *
-    * {{{
-    *   def square(x: Double): Double = x * x
-    * }}}
-    *
-    * When you invoke `square(41.0 + 1.0)`, the function `square` will receive the evaluated value of `42.0` because
-    * it's strict. If you invoke `square(sys.error("failure"))`, you’ll get an exception before square has a chance to do
-    * anything, since the `sys.error("failure")` expression will be evaluated before entering the body of square.
-    *
-    * For example, the short-circuiting Boolean functions `&&` and `||`, found in many programming languages including
-    * Scala, are non-strict. You can think of them as functions that may choose not to evaluate their arguments. The
-    * function `&&` takes two `Boolean` arguments, but only evaluates the second argument if the first is `true`:
-    *
-    * {{{
-    *   false && { println("!!"); true } // does not print anything
-    * }}}
-    *
-    * And `||` only evaluates its second argument if the first is `false`:
-    *
-    * {{{
-    *   true || { println("!!"); false } // doesn't print anything either
-    * }}}
-    *
-    * Another example of non-strictness is the `if` control construct in Scala. It can be thought of as a function
-    * accepting three parameters: a condition of type `Boolean`, an expression of some type `A` to return in the case that
-    * the condition is `true`, and another expression of the same type `A` to return if the condition is `false`. We'd
-    * say that the if function is strict in its condition parameter, since it’ll always evaluate the condition to
-    * determine which branch to take, and non-strict in the two branches for the `true` and `false` cases,
-    * since it’ll only evaluate one or the other based on the condition. We can re-implement it the following way:
-    *
-    * {{{
-    *   def if2[A](cond: Boolean, onTrue: () => A, onFalse: () => A): A =
-    *     if (cond) onTrue() else onFalse()
-    * }}}
-    *
-    * Play around with it for a bit and note what happens when you force a `true` or a `false` condition on the `if2`
-    * call:
-    */
-
-  def if2Assert(res0: Boolean): Unit = {
-    if2(res0, () => true, () => { sys.error("Exception occurred: if2 call went through the false branch") })
-  }
-
-  /**
-    * The arguments we’d like to pass unevaluated have a `() =>` immediately before their type. A value of type
-    * `() => A` is a function that accepts zero arguments and returns an `A`. In general, the unevaluated form of an
-    * expression is called a `thunk`, and we can force the thunk to evaluate the expression and get a result. We do
-    * so by invoking the function, passing an empty argument list, as in `onTrue()` or `onFalse()`. Likewise, callers
-    * of `if2` have to explicitly create thunks, and the syntax follows the same conventions as the function literal
-    * syntax we’ve already seen. But this is such a common case that Scala provides some nicer syntax:
-    *
-    * {{{
-    *   def if2[A](cond: Boolean, onTrue: => A, onFalse: => A): A =
-    *     if (cond) onTrue else onFalse
-    *
-    *   if2(false, sys.error("fail"), 3)
-    * }}}
-    *
-    * With either syntax, an argument that’s passed unevaluated to a function will be evaluated once for each place
-    * it’s referenced in the body of the function. That is, Scala won’t (by default) cache the result of evaluating an
-    * argument:
-    *
-    * {{{
-    *   def maybeTwice(b: Boolean, i: => Int) = if (b) i+i else 0
-    *
-    *   scala> val x = maybeTwice(true, { println("hi"); 1 + 41 })
-    *   hi
-    *   hi
-    *   x: Int = 84
-    * }}}
-    *
-    * Here, i is referenced twice in the body of maybeTwice, and we’ve made it particularly obvious that it’s evaluated
-    * each time by passing the block `{ println("hi"); 1+41 }`, which prints hi as a side effect before returning a
-    * result of `42`. The expression `1 + 41` will be computed twice as well. We can cache the value explicitly if we
-    * wish to only evaluate the result once, by using the `lazy` keyword:
-    *
-    * {{{
-    *   def maybeTwice2(b: Boolean, i: => Int) = {
-    *     lazy val j = i
-    *     if (b) j + j else 0
-    *   }
-    *
-    *   scala> val x = maybeTwice2(true, { println("hi"); 1 + 41 })
-    *   hi
-    *   x: Int = 84
-    * }}}
-    *
-    * Adding the `lazy` keyword to a `val` declaration will cause Scala to delay evaluation of the right-hand side of that
-    * `lazy val` declaration until it’s first referenced. It will also cache the result so that any subsequent references
-    * to it won’t trigger repeat evaluations.
-    *
-    * = Lazy lists =
-    *
-    * We’ll explore how laziness can be used to improve the efficiency and modularity of functional programs using lazy
-    * lists, or streams, as an example.
-    *
-    * {{{
-    *   sealed trait Stream[+A]
-    *   case object Empty extends Stream[Nothing]
-    *   case class Cons[+A](h: () => A, t: () => Stream[A]) extends Stream[A]
-    *
-    *   object Stream {
-    *     def cons[A](hd: => A, tl: => Stream[A]): Stream[A] = {
-    *       lazy val head = hd
-    *       lazy val tail = tl
-    *       Cons(() => head, () => tail)
-    *     }
-    *     def empty[A]: Stream[A] = Empty
-    *
-    *     def apply[A](as: A*): Stream[A] =
-    *       if (as.isEmpty) empty else cons(as.head, apply(as.tail: _*))
-    *   }
-    * }}}
-    *
-    * This type looks identical to our List type, except that the Cons data constructor takes `explicit` thunks
-    * `(() => A and () => Stream[A])` instead of regular strict values. If we wish to examine or traverse the Stream,
-    * we need to force these thunks as we did earlier in our definition of `if2`. For example:
-    *
-    * {{{
-    *   def headOption: Option[A] = this match {
-    *     case Empty => None
-    *     case Cons(h, t) => Some(h())  // explicit forcing of h using h()
-    *   }
-    * }}}
-    *
+    * <b>Exercise 5.1:</b>
     *
     * Now let's write a few helper functions to make inspecting streams easier, starting with a function to convert a
     * `Stream` to a `List` (which will force its evaluation):
@@ -167,6 +39,8 @@ object StrictnessAndLazinessSection extends FlatSpec with Matchers with org.scal
   }
 
   /**
+    * <b>Exercise 5.2:</b>
+    *
     * Let's continue by writing the function `take` for returning the first `n` elements of a `Stream`. Note that in the
     * following implementation, we're using `Stream`'s smart constructors `cons` and `empty`, defined as follows:
     *
@@ -205,7 +79,9 @@ object StrictnessAndLazinessSection extends FlatSpec with Matchers with org.scal
   }
 
   /**
-    * We can also implement `takeWhile` to return all starting elements of a `Stream` that match the given predicate:
+    * <b>Exercise 5.3:</b>
+    *
+    * We can also implement `takeWhile` to return all starting elements of a `Stream` that match a given predicate:
     */
 
   def streamTakeWhileAssert(res0: List[Int], res1: List[Int]): Unit = {
@@ -233,29 +109,10 @@ object StrictnessAndLazinessSection extends FlatSpec with Matchers with org.scal
     *   }
     * }}}
     *
-    * Note that `||` is non-strict in its second argument. If `p(h())` returns `true`, then exists terminates the
-    * traversal early and returns true as well. Remember also that the tail of the stream is a `lazy val`. So not only
-    * does the traversal terminate early, the tail of the stream is never evaluated at all!
+    * <b>Exercise 5.4:</b>
     *
-    * We can implement a `foldRight` similar to that of `List`, but expressed in a lazy way:
-    *
-    * {{{
-    *   def foldRight[B](z: => B)(f: (A, => B) => B): B = this match {
-    *     case Cons(h,t) => f(h(), t().foldRight(z)(f))
-    *     case _ => z
-    *   }
-    * }}}
-    *
-    * This looks very similar to the `foldRight` we wrote for `List`, but note how our combining function `f` is
-    * non-strict in its second parameter. If `f` chooses not to evaluate its second parameter, this terminates the
-    * traversal early. We can see this by using `foldRight` to implement `exists`:
-    *
-    * {{{
-    *   def exists(p: A => Boolean): Boolean = foldRight(false)((a, b) => p(a) || b)
-    * }}}
-    *
-    * Let's use this to implement `forAll`, which checks that all elements in the `Stream` match a given predicate. Note
-    * that the implementation will terminate the traversal as soon as it encounters a non-matching value.
+    * Let's implement `forAll`, a function that checks that all elements in the `Stream` match a given predicate. Note
+    * that the implementation will stop as soon as it encounters a non-matching value.
     */
 
   def streamForAllAssert(res0: Boolean): Unit = {
@@ -267,6 +124,8 @@ object StrictnessAndLazinessSection extends FlatSpec with Matchers with org.scal
   }
 
   /**
+    * <b>Exercise 5.5:</b>
+    *
     * Let's put `foldRight` to good use, by implementing `takeWhile` based on it:
     *
     * {{{
@@ -276,11 +135,15 @@ object StrictnessAndLazinessSection extends FlatSpec with Matchers with org.scal
     *       else      empty)
     * }}}
     *
+    * <b>Exercise 5.6:</b>
+    *
     * We can also do the same with `headOption`:
     *
     * {{{
     *   def headOption: Option[A] = foldRight(None: Option[A])((h,_) => Some(h))
     * }}}
+    *
+    * <b>Exercise 5.7:</b>
     *
     * Implementations for `map`, `filter`, `append` and `flatMap` using `foldRight` should sound familiar already:
     *
@@ -296,9 +159,9 @@ object StrictnessAndLazinessSection extends FlatSpec with Matchers with org.scal
     *   def flatMap[B](f: A => Stream[B]): Stream[B] = foldRight(empty[B])((h,t) => f(h) append t)
     * }}}
     *
-    * Note that these implementations are incremental — they don’t fully generate their answers. It’s not until another
-    * computation looks at the elements of the resulting `Stream` that the computation to generate that `Stream`
-    * actually takes place. Let's look at a simplified program trace for the next piece of code.
+    * <b>Exercise 5.x:</b>
+    *
+    * Let's look at a simplified program trace for the next piece of code.
     *
     * {{{
     *   Stream(1, 2, 3, 4).map(_ + 10).filter(_ % 2 == 0)
@@ -340,15 +203,16 @@ object StrictnessAndLazinessSection extends FlatSpec with Matchers with org.scal
   /**
     * = Infinite streams and corecursion =
     *
-    * Because they’re incremental, the functions we’ve written also work for `infinite streams`. Here’s an example of
-    * an infinite `Stream` of `1`s:
+    * <b>Exercise 5.x:</b>
+    *
+    * Here’s an example of an infinite `Stream` of `1`s:
     *
     * {{{
     *   val ones: Stream[Int] = Stream.cons(1, ones)
     * }}}
     *
-    * Although ones is infinite, the functions we’ve written so far only inspect the portion of the stream needed to
-    * generate the demanded output. For example:
+    * The functions we’ve written so far only inspect the portion of the stream needed to generate the demanded output.
+    * Take a look at this example:
     */
 
   def streamOnesAssert(res0: List[Int], res1: Boolean, res2: Boolean, res3: Boolean): Unit = {
@@ -359,6 +223,8 @@ object StrictnessAndLazinessSection extends FlatSpec with Matchers with org.scal
   }
 
   /**
+    * <b>Exercise 5.8:</b>
+    *
     * Let's generalize `ones` slightly to the function `constant`, which returns an infinite `Stream` of a given value:
     *
     * {{{
@@ -367,6 +233,8 @@ object StrictnessAndLazinessSection extends FlatSpec with Matchers with org.scal
     *     tail
     *   }
     * }}}
+    *
+    * <b>Exercise 5.9:</b>
     *
     * Of course, we can generate `number series` with `Stream`s. For example, let's write a function that generates an
     * infinite stream of integers (n, n + 1, n + 2...):
@@ -380,6 +248,8 @@ object StrictnessAndLazinessSection extends FlatSpec with Matchers with org.scal
   }
 
   /**
+    * <b>Exercise 5.10:</b>
+    *
     * We can also create a function `fibs` that generates the infinite stream of Fibonacci numbers: 0, 1, 1, 2, 3, 5, 8...
     */
 
@@ -394,8 +264,10 @@ object StrictnessAndLazinessSection extends FlatSpec with Matchers with org.scal
   }
 
   /**
-    * Now we're going to write a more general stream-building function called `unfold`. It takes an initial state, and
-    * a function for producing both the next state and the next value in the generated stream:
+    * <b>Exercise 5.11:</b>
+    *
+    * Now we're going to write a more general stream-building function: `unfold` which takes an initial state, and
+    * a function for building both the next state and the next value in the stream to be generated:
     *
     * {{{
     *   def unfold[A, S](z: S)(f: S => Option[(A, S)]): Stream[A] = f(z) match {
@@ -404,8 +276,9 @@ object StrictnessAndLazinessSection extends FlatSpec with Matchers with org.scal
     *   }
     * }}}
     *
-    * `Option` is used to indicate when the `Stream` should be terminated, if at all. Now that we have `unfold`, let's
-    * rewrite our previous generator functions based on it, starting from `fibs`:
+    * <b>Exercise 5.12:</b>
+    *
+    * Now that we have `unfold`, let's rewrite our previous generator functions based on it, starting from `fibs`:
     */
 
   def streamFibsViaUnfoldAssert(res0: Int, res1: Int): Unit = {
@@ -442,6 +315,8 @@ object StrictnessAndLazinessSection extends FlatSpec with Matchers with org.scal
   }
 
   /**
+    * <b>Exercise 5.13:</b>
+    *
     * Now we're going to re-implement some of the higher-order functions for `Stream`s, starting with map:
     *
     * {{{
@@ -500,6 +375,8 @@ object StrictnessAndLazinessSection extends FlatSpec with Matchers with org.scal
     *   }
     * }}}
     *
+    * <b>Exercise 5.14:</b>
+    *
     * Now we're going to try to implement `startsWith` using the functions we've seen so far:
     *
     * {{{
@@ -509,8 +386,10 @@ object StrictnessAndLazinessSection extends FlatSpec with Matchers with org.scal
     *     }
     * }}}
     *
-    * We can also write `tails` using `unfold`. For a given Stream, `tails` returns the `Stream` of suffixes of the input
-    * sequence, starting with the original `Stream`. For example, given `Stream(1,2,3)`, it would return
+    * <b>Exercise 5.15:</b>
+    *
+    * We can also write `tails` using `unfold`. `tails` returns the `Stream` of suffixes of a given `Stream`,
+    * starting with the original `Stream`. For example, for `Stream(1,2,3)`, it should return
     * `Stream(Stream(1,2,3), Stream(2,3), Stream(3), Stream())`.
     */
 
@@ -525,6 +404,8 @@ object StrictnessAndLazinessSection extends FlatSpec with Matchers with org.scal
   }
 
   /**
+    * <b>Exercise 5.16:</b>
+    *
     * We can generalize tails to the function scanRight, which is like a `foldRight` that returns a stream of the
     * intermediate results:
     *

--- a/src/test/scala/fpinscalalib/ErrorHandlingSpec.scala
+++ b/src/test/scala/fpinscalalib/ErrorHandlingSpec.scala
@@ -11,12 +11,6 @@ import fpinscalalib.customlib.errorhandling.Employee
 import fpinscalalib.customlib.errorhandling.ExampleHelper._
 
 class ErrorHandlingSpec extends Spec with Checkers {
-  def `option mean asserts` = {
-    val none : Option[Double] = None
-
-    check(Test.testSuccess(ErrorHandlingSection.optionMeanAssert _, none :: HNil))
-  }
-
   def `option map asserts` = {
     val f = (e: Option[Employee]) => e.map(_.department)
 
@@ -48,10 +42,6 @@ class ErrorHandlingSpec extends Spec with Checkers {
   def `option traverse asserts` = {
     val none : Option[List[Int]] = None
     check(Test.testSuccess(ErrorHandlingSection.optionTraverseAssert _, Some(List(1, 2, 3)) :: none :: HNil))
-  }
-
-  def `either mean asserts` = {
-    check(Test.testSuccess(ErrorHandlingSection.eitherMeanAssert _, Right(3.0) :: Left("mean of empty list!") :: HNil))
   }
 
   def `either map asserts` = {

--- a/src/test/scala/fpinscalalib/FunctionalDataStructuresSpec.scala
+++ b/src/test/scala/fpinscalalib/FunctionalDataStructuresSpec.scala
@@ -10,10 +10,6 @@ import shapeless.HNil
 import fpinscalalib.customlib.functionaldatastructures._
 
 class FunctionalDataStructuresSpec extends Spec with Checkers {
-  def `pattern matching 101 asserts` = {
-    check(Test.testSuccess(FunctionalDataStructuresSection.patternMatching101Assert _,
-      42 :: 1 :: List(2, 3) :: HNil))
-  }
 
   def `complex pattern matching asserts` = {
     check(Test.testSuccess(FunctionalDataStructuresSection.complexPatternAssert _, 3 :: HNil))

--- a/src/test/scala/fpinscalalib/FunctionalParalellismSpec.scala
+++ b/src/test/scala/fpinscalalib/FunctionalParalellismSpec.scala
@@ -12,20 +12,8 @@ class FunctionalParalellismSpec extends Spec with Checkers {
     check(Test.testSuccess(FunctionalParallelismSection.parAsyncFAssert _, "10" :: HNil))
   }
 
-  def `par sortPar asserts` = {
-    FunctionalParallelismSection.parSortParAssert((l: List[Int]) => l.sorted)
-  }
-
   def `par filter asserts` = {
     FunctionalParallelismSection.parFilterAssert(List(1, 2, 3))
-  }
-
-  def `par law mapping asserts` = {
-    FunctionalParallelismSection.parLawMappingAssert(2)
-  }
-
-  def `par equal asserts` = {
-    FunctionalParallelismSection.parEqualAssert(true)
   }
 
   def `par choiceN asserts` = {

--- a/src/test/scala/fpinscalalib/FunctionalStateSpec.scala
+++ b/src/test/scala/fpinscalalib/FunctionalStateSpec.scala
@@ -20,10 +20,6 @@ class FunctionalStateSpec extends Spec with Checkers {
     FunctionalStateSection.randomIntListAssert(0, 1)
   }
 
-  def `random not negative even integer asserts` = {
-    FunctionalStateSection.randomNonNegativeEvenAssert(2)
-  }
-
   def `random doubles via map asserts` = {
     FunctionalStateSection.randomDoubleViaMap(1)
   }

--- a/src/test/scala/fpinscalalib/StrictnessAndLazinessSpec.scala
+++ b/src/test/scala/fpinscalalib/StrictnessAndLazinessSpec.scala
@@ -19,10 +19,6 @@ class StrictnessAndLazinessSpec extends Spec with Checkers {
         (1, const(Stream.empty)))))
   }
 
-  def `if2 asserts` = {
-    check(Test.testSuccess(StrictnessAndLazinessSection.if2Assert _, true :: HNil))
-  }
-
   def `stream toList asserts` = {
     check(Test.testSuccess(StrictnessAndLazinessSection.streamToListAssert _, List(1, 2, 3) :: HNil))
   }


### PR DESCRIPTION
**DO NOT MERGE**

This PR removes all excerpts of theory illustrating the exercises in all published sections, leaving only references to the exercise numerations and short descriptions of each one when needed.

Could you please review, @raulraja @juanpedromoreno? Thanks!