### PR TITLE
Fix library title in scala-exercises main page

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
-# exercises-fpinscala
-
 #Scala Exercises - "Functional Programming in Scala" library
 
 ------------------------

--- a/src/main/scala/fpinscalalib/FPinScalaLibrary.scala
+++ b/src/main/scala/fpinscalalib/FPinScalaLibrary.scala
@@ -2,9 +2,7 @@ package fpinscalalib
 
 import org.scalaexercises.definitions._
 
-/** Exercises based on Manning's "Functional Programming in Scala" by by Paul Chiusano and Rúnar Bjarnason.
-  * For more information about the book please visit its
-  * <a href="https://www.manning.com/books/functional-programming-in-scala">official website</a>.
+/** Exercises based on Manning's "Functional Programming in Scala" book by Paul Chiusano and Rúnar Bjarnason.
   *
   * @param name fp_in_scala
   */


### PR DESCRIPTION
This PR includes a small change in the library to shorten the introduction text shown in scala-exercises main site, as a temporary solution to #20 (which will receive a proper fix in another PR) in order to be published as soon as possible.

Could you please review, @raulraja @juanpedromoreno? Thanks!