### PR TITLE
Update to Scala 2.12.10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: scala
 scala:
-- 2.11.11
+- 2.12.10
 jdk:
 - openjdk8
 script:

--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,5 @@
-val scalaExercisesV = "0.4.0-SNAPSHOT"
+import ProjectPlugin.autoImport._
+val scalaExercisesV = "0.5.0-SNAPSHOT"
 
 def dep(artifactId: String) = "org.scala-exercises" %% artifactId % scalaExercisesV
 
@@ -9,9 +10,10 @@ lazy val fpinscala = (project in file("."))
     libraryDependencies ++= Seq(
       dep("exercise-compiler"),
       dep("definitions"),
-      %%("scalatest"),
-      %%("scalacheck"),
-      %%("scheckShapeless")
+      %%("shapeless", V.shapeless),
+      %%("scalatest", V.scalatest),
+      %%("scalacheck", V.scalacheck),
+      "com.github.alexarchambault" %% "scalacheck-shapeless_1.14" % V.scalacheckShapeless
     )
   )
 

--- a/project/ProjectPlugin.scala
+++ b/project/ProjectPlugin.scala
@@ -16,7 +16,6 @@ object ProjectPlugin extends AutoPlugin {
 
     lazy val V = new {
       val scala212: String            = "2.12.10"
-      val cats: String = "2.0.0"
       val shapeless: String           = "2.3.3"
       val scalatest: String           = "3.0.8"
       val scalacheck: String          = "1.14.2"

--- a/project/ProjectPlugin.scala
+++ b/project/ProjectPlugin.scala
@@ -1,4 +1,4 @@
-import de.heikoseeberger.sbtheader.HeaderPattern
+import de.heikoseeberger.sbtheader.License._
 import de.heikoseeberger.sbtheader.HeaderPlugin.autoImport._
 import sbt.Keys._
 import sbt._
@@ -11,6 +11,20 @@ object ProjectPlugin extends AutoPlugin {
   override def trigger: PluginTrigger = allRequirements
 
   override def requires: Plugins = plugins.JvmPlugin && OrgPoliciesPlugin
+
+  object autoImport {
+
+    lazy val V = new {
+      val scala212: String            = "2.12.10"
+      val cats: String = "2.0.0"
+      val shapeless: String           = "2.3.3"
+      val scalatest: String           = "3.0.8"
+      val scalacheck: String          = "1.14.2"
+      val scalacheckShapeless: String = "1.2.3"
+    }
+  }
+
+  import autoImport._
 
   override def projectSettings: Seq[Def.Setting[_]] =
     Seq(
@@ -25,23 +39,17 @@ object ProjectPlugin extends AutoPlugin {
         organizationEmail = "hello@47deg.com"
       ),
       orgLicenseSetting := ApacheLicense,
-      scalaVersion := "2.11.11",
+      scalaVersion := V.scala212,
       scalaOrganization := "org.scala-lang",
-      crossScalaVersions := Seq("2.11.11"),
       resolvers ++= Seq(
         Resolver.mavenLocal,
         Resolver.sonatypeRepo("snapshots"),
         Resolver.sonatypeRepo("releases")
       ),
       scalacOptions := scalacCommonOptions ++ scalacLanguageOptions,
-      headers := Map(
-        "scala" -> (HeaderPattern.cStyleBlockComment,
-          s"""|/*
-              | * scala-exercises - ${name.value}
-              | * Copyright (C) 2015-2016 47 Degrees, LLC. <http://www.47deg.com>
-              | */
-              |
-            |""".stripMargin)
-      )
+      headerLicense := Some(Custom(s"""| scala-exercises - ${name.value}
+                                       | Copyright (C) 2015-2019 47 Degrees, LLC. <http://www.47deg.com>
+                                       |
+                                       |""".stripMargin))
     )
 }

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.13
+sbt.version=1.2.8

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -2,5 +2,5 @@ resolvers ++= Seq(
   Resolver.sonatypeRepo("snapshots")
 )
 
-addSbtPlugin("org.scala-exercises" % "sbt-exercise" % "0.4.0-SNAPSHOT", "0.13", "2.10")
-addSbtPlugin("com.47deg"         % "sbt-org-policies" % "0.5.13")
+addSbtPlugin("org.scala-exercises" % "sbt-exercise" % "0.5.0-SNAPSHOT")
+addSbtPlugin("com.47deg"         % "sbt-org-policies" % "0.12.0-M3")

--- a/src/main/scala/fpinscalalib/ErrorHandlingSection.scala
+++ b/src/main/scala/fpinscalalib/ErrorHandlingSection.scala
@@ -1,6 +1,7 @@
 /*
- * scala-exercises - exercises-fpinscala
- * Copyright (C) 2015-2016 47 Degrees, LLC. <http://www.47deg.com>
+ *  scala-exercises - exercises-fpinscala
+ *  Copyright (C) 2015-2019 47 Degrees, LLC. <http://www.47deg.com>
+ *
  */
 
 package fpinscalalib

--- a/src/main/scala/fpinscalalib/FPinScalaLibrary.scala
+++ b/src/main/scala/fpinscalalib/FPinScalaLibrary.scala
@@ -1,6 +1,7 @@
 /*
- * scala-exercises - exercises-fpinscala
- * Copyright (C) 2015-2016 47 Degrees, LLC. <http://www.47deg.com>
+ *  scala-exercises - exercises-fpinscala
+ *  Copyright (C) 2015-2019 47 Degrees, LLC. <http://www.47deg.com>
+ *
  */
 
 package fpinscalalib

--- a/src/main/scala/fpinscalalib/FunctionalDataStructuresSection.scala
+++ b/src/main/scala/fpinscalalib/FunctionalDataStructuresSection.scala
@@ -1,12 +1,12 @@
 /*
- * scala-exercises - exercises-fpinscala
- * Copyright (C) 2015-2016 47 Degrees, LLC. <http://www.47deg.com>
+ *  scala-exercises - exercises-fpinscala
+ *  Copyright (C) 2015-2019 47 Degrees, LLC. <http://www.47deg.com>
+ *
  */
 
 package fpinscalalib
 
 import org.scalatest.{FlatSpec, Matchers}
-import fpinscalalib.customlib._
 import fpinscalalib.customlib.functionaldatastructures._
 import fpinscalalib.customlib.functionaldatastructures.List._
 import Tree._

--- a/src/main/scala/fpinscalalib/FunctionalParallelismSection.scala
+++ b/src/main/scala/fpinscalalib/FunctionalParallelismSection.scala
@@ -1,11 +1,10 @@
 /*
- * scala-exercises - exercises-fpinscala
- * Copyright (C) 2015-2016 47 Degrees, LLC. <http://www.47deg.com>
+ *  scala-exercises - exercises-fpinscala
+ *  Copyright (C) 2015-2019 47 Degrees, LLC. <http://www.47deg.com>
+ *
  */
 
 package fpinscalalib
-
-import java.util.concurrent.ExecutorService
 
 import fpinscalalib.customlib.functionalparallelism.Par
 import fpinscalalib.customlib.functionalparallelism.Par._

--- a/src/main/scala/fpinscalalib/FunctionalStateSection.scala
+++ b/src/main/scala/fpinscalalib/FunctionalStateSection.scala
@@ -1,6 +1,7 @@
 /*
- * scala-exercises - exercises-fpinscala
- * Copyright (C) 2015-2016 47 Degrees, LLC. <http://www.47deg.com>
+ *  scala-exercises - exercises-fpinscala
+ *  Copyright (C) 2015-2019 47 Degrees, LLC. <http://www.47deg.com>
+ *
  */
 
 package fpinscalalib
@@ -8,7 +9,6 @@ package fpinscalalib
 import fpinscalalib.customlib.state.RNG.Simple
 import fpinscalalib.customlib.state.RNG._
 import org.scalatest.{FlatSpec, Matchers}
-import org.scalacheck.Shapeless._
 import fpinscalalib.customlib.state._
 
 /** @param name pure_functional_state

--- a/src/main/scala/fpinscalalib/GettingStartedWithFPSection.scala
+++ b/src/main/scala/fpinscalalib/GettingStartedWithFPSection.scala
@@ -1,6 +1,7 @@
 /*
- * scala-exercises - exercises-fpinscala
- * Copyright (C) 2015-2016 47 Degrees, LLC. <http://www.47deg.com>
+ *  scala-exercises - exercises-fpinscala
+ *  Copyright (C) 2015-2019 47 Degrees, LLC. <http://www.47deg.com>
+ *
  */
 
 package fpinscalalib

--- a/src/main/scala/fpinscalalib/ParserCombinatorsSection.scala
+++ b/src/main/scala/fpinscalalib/ParserCombinatorsSection.scala
@@ -1,17 +1,18 @@
 /*
- * scala-exercises - exercises-fpinscala
- * Copyright (C) 2015-2016 47 Degrees, LLC. <http://www.47deg.com>
+ *  scala-exercises - exercises-fpinscala
+ *  Copyright (C) 2015-2019 47 Degrees, LLC. <http://www.47deg.com>
+ *
  */
 
 package fpinscalalib
 
 import org.scalatest.{FlatSpec, Matchers}
-import fpinscalalib.customlib.parsing.{JSON, Location, ParseError, Reference}
+import fpinscalalib.customlib.parsing.{JSON, ParseError, Reference}
 import fpinscalalib.customlib.parsing.ReferenceTypes._
 import Reference._
 import scala.util.matching.Regex
 
-/** @param name parser_combinators
+/** @param name parser_combinatorss
  */
 object ParserCombinatorsSection
     extends FlatSpec

--- a/src/main/scala/fpinscalalib/PropertyBasedTestingSection.scala
+++ b/src/main/scala/fpinscalalib/PropertyBasedTestingSection.scala
@@ -1,16 +1,14 @@
 /*
- * scala-exercises - exercises-fpinscala
- * Copyright (C) 2015-2016 47 Degrees, LLC. <http://www.47deg.com>
+ *  scala-exercises - exercises-fpinscala
+ *  Copyright (C) 2015-2019 47 Degrees, LLC. <http://www.47deg.com>
+ *
  */
 
 package fpinscalalib
 
-import java.util.concurrent.Executors
-
-import fpinscalalib.customlib.functionalparallelism.Par
 import fpinscalalib.customlib.state.{RNG, State}
 import org.scalatest.{FlatSpec, Matchers}
-import fpinscalalib.customlib.testing.{Gen, Prop, SGen}
+import fpinscalalib.customlib.testing.{Gen, SGen}
 import fpinscalalib.customlib.testing.Gen._
 import fpinscalalib.customlib.testing.Prop._
 

--- a/src/main/scala/fpinscalalib/StrictnessAndLazinessSection.scala
+++ b/src/main/scala/fpinscalalib/StrictnessAndLazinessSection.scala
@@ -1,6 +1,7 @@
 /*
- * scala-exercises - exercises-fpinscala
- * Copyright (C) 2015-2016 47 Degrees, LLC. <http://www.47deg.com>
+ *  scala-exercises - exercises-fpinscala
+ *  Copyright (C) 2015-2019 47 Degrees, LLC. <http://www.47deg.com>
+ *
  */
 
 package fpinscalalib
@@ -9,7 +10,6 @@ import fpinscalalib.customlib.laziness._
 import fpinscalalib.customlib.laziness.Stream
 import fpinscalalib.customlib.laziness.Stream._
 import org.scalatest.{FlatSpec, Matchers}
-import fpinscalalib.customlib.laziness.ExampleHelper._
 
 /** @param name strictness_and_laziness
  */

--- a/src/main/scala/fpinscalalib/customlib/errorhandling/EitherHelper.scala
+++ b/src/main/scala/fpinscalalib/customlib/errorhandling/EitherHelper.scala
@@ -1,6 +1,7 @@
 /*
- * scala-exercises - exercises-fpinscala
- * Copyright (C) 2015-2016 47 Degrees, LLC. <http://www.47deg.com>
+ *  scala-exercises - exercises-fpinscala
+ *  Copyright (C) 2015-2019 47 Degrees, LLC. <http://www.47deg.com>
+ *
  */
 
 package fpinscalalib.customlib.errorhandling

--- a/src/main/scala/fpinscalalib/customlib/errorhandling/ExampleHelper.scala
+++ b/src/main/scala/fpinscalalib/customlib/errorhandling/ExampleHelper.scala
@@ -1,6 +1,7 @@
 /*
- * scala-exercises - exercises-fpinscala
- * Copyright (C) 2015-2016 47 Degrees, LLC. <http://www.47deg.com>
+ *  scala-exercises - exercises-fpinscala
+ *  Copyright (C) 2015-2019 47 Degrees, LLC. <http://www.47deg.com>
+ *
  */
 
 package fpinscalalib.customlib.errorhandling

--- a/src/main/scala/fpinscalalib/customlib/errorhandling/OptionHelper.scala
+++ b/src/main/scala/fpinscalalib/customlib/errorhandling/OptionHelper.scala
@@ -1,6 +1,7 @@
 /*
- * scala-exercises - exercises-fpinscala
- * Copyright (C) 2015-2016 47 Degrees, LLC. <http://www.47deg.com>
+ *  scala-exercises - exercises-fpinscala
+ *  Copyright (C) 2015-2019 47 Degrees, LLC. <http://www.47deg.com>
+ *
  */
 
 package fpinscalalib.customlib.errorhandling

--- a/src/main/scala/fpinscalalib/customlib/functionaldatastructures/ListHelper.scala
+++ b/src/main/scala/fpinscalalib/customlib/functionaldatastructures/ListHelper.scala
@@ -1,6 +1,7 @@
 /*
- * scala-exercises - exercises-fpinscala
- * Copyright (C) 2015-2016 47 Degrees, LLC. <http://www.47deg.com>
+ *  scala-exercises - exercises-fpinscala
+ *  Copyright (C) 2015-2019 47 Degrees, LLC. <http://www.47deg.com>
+ *
  */
 
 package fpinscalalib.customlib.functionaldatastructures

--- a/src/main/scala/fpinscalalib/customlib/functionaldatastructures/TreeHelper.scala
+++ b/src/main/scala/fpinscalalib/customlib/functionaldatastructures/TreeHelper.scala
@@ -1,6 +1,7 @@
 /*
- * scala-exercises - exercises-fpinscala
- * Copyright (C) 2015-2016 47 Degrees, LLC. <http://www.47deg.com>
+ *  scala-exercises - exercises-fpinscala
+ *  Copyright (C) 2015-2019 47 Degrees, LLC. <http://www.47deg.com>
+ *
  */
 
 package fpinscalalib.customlib.functionaldatastructures

--- a/src/main/scala/fpinscalalib/customlib/functionalparallelism/ParHelper.scala
+++ b/src/main/scala/fpinscalalib/customlib/functionalparallelism/ParHelper.scala
@@ -1,6 +1,7 @@
 /*
- * scala-exercises - exercises-fpinscala
- * Copyright (C) 2015-2016 47 Degrees, LLC. <http://www.47deg.com>
+ *  scala-exercises - exercises-fpinscala
+ *  Copyright (C) 2015-2019 47 Degrees, LLC. <http://www.47deg.com>
+ *
  */
 
 package fpinscalalib.customlib.functionalparallelism
@@ -148,7 +149,6 @@ object Par {
 }
 
 object Examples {
-  import Par._
   def sum(ints: IndexedSeq[Int]): Int = // `IndexedSeq` is a superclass of random-access sequences like `Vector` in the standard library. Unlike lists, these sequences provide an efficient `splitAt` method for dividing them into two parts at a particular index.
     if (ints.size <= 1)
       ints.headOption getOrElse 0 // `headOption` is a method defined on all collections in Scala. We saw this function in chapter 3.

--- a/src/main/scala/fpinscalalib/customlib/laziness/ExampleHelper.scala
+++ b/src/main/scala/fpinscalalib/customlib/laziness/ExampleHelper.scala
@@ -1,6 +1,7 @@
 /*
- * scala-exercises - exercises-fpinscala
- * Copyright (C) 2015-2016 47 Degrees, LLC. <http://www.47deg.com>
+ *  scala-exercises - exercises-fpinscala
+ *  Copyright (C) 2015-2019 47 Degrees, LLC. <http://www.47deg.com>
+ *
  */
 
 package fpinscalalib.customlib.laziness

--- a/src/main/scala/fpinscalalib/customlib/laziness/StreamHelper.scala
+++ b/src/main/scala/fpinscalalib/customlib/laziness/StreamHelper.scala
@@ -1,6 +1,7 @@
 /*
- * scala-exercises - exercises-fpinscala
- * Copyright (C) 2015-2016 47 Degrees, LLC. <http://www.47deg.com>
+ *  scala-exercises - exercises-fpinscala
+ *  Copyright (C) 2015-2019 47 Degrees, LLC. <http://www.47deg.com>
+ *
  */
 
 package fpinscalalib.customlib.laziness
@@ -160,7 +161,7 @@ trait Stream[+A] {
   def zipWithAll[B, C](s2: Stream[B])(f: (Option[A], Option[B]) => C): Stream[C] =
     Stream.unfold((this, s2)) {
       case (Empty, Empty)               => None
-      case (Cons(h, t), Empty)          => Some(f(Some(h()), Option.empty[B]) -> (t(), empty[B]))
+      case (Cons(h, t), Empty)          => Some(f(Some(h()), Option.empty[B]) -> Tuple2(t(), empty[B]))
       case (Empty, Cons(h, t))          => Some(f(Option.empty[A], Some(h())) -> (empty[A] -> t()))
       case (Cons(h1, t1), Cons(h2, t2)) => Some(f(Some(h1()), Some(h2())) -> (t1() -> t2()))
     }
@@ -168,8 +169,8 @@ trait Stream[+A] {
   /*
   `s startsWith s2` when corresponding elements of `s` and `s2` are all equal, until the point that `s2` is exhausted. If `s` is exhausted first, or we find an element that doesn't match, we terminate early. Using non-strictness, we can compose these three separate logical steps--the zipping, the termination when the second stream is exhausted, and the termination if a nonmatching element is found or the first stream is exhausted.
    */
-  def startsWith[A](s: Stream[A]): Boolean =
-    zipAll(s).takeWhile(!_._2.isEmpty) forAll {
+  def startsWith[T](s: Stream[T]): Boolean =
+    zipAll(s).takeWhile(_._2.isDefined) forAll {
       case (h, h2) => h == h2
     }
 
@@ -182,7 +183,7 @@ trait Stream[+A] {
       case s     => Some((s, s drop 1))
     } append Stream(empty)
 
-  def hasSubsequence[A](s: Stream[A]): Boolean =
+  def hasSubsequence[T](s: Stream[T]): Boolean =
     tails exists (_ startsWith s)
 
   /*

--- a/src/main/scala/fpinscalalib/customlib/parsing/JSON.scala
+++ b/src/main/scala/fpinscalalib/customlib/parsing/JSON.scala
@@ -1,6 +1,7 @@
 /*
- * scala-exercises - exercises-fpinscala
- * Copyright (C) 2015-2016 47 Degrees, LLC. <http://www.47deg.com>
+ *  scala-exercises - exercises-fpinscala
+ *  Copyright (C) 2015-2019 47 Degrees, LLC. <http://www.47deg.com>
+ *
  */
 
 package fpinscalalib.customlib.parsing

--- a/src/main/scala/fpinscalalib/customlib/parsing/ParsersHelper.scala
+++ b/src/main/scala/fpinscalalib/customlib/parsing/ParsersHelper.scala
@@ -1,6 +1,7 @@
 /*
- * scala-exercises - exercises-fpinscala
- * Copyright (C) 2015-2016 47 Degrees, LLC. <http://www.47deg.com>
+ *  scala-exercises - exercises-fpinscala
+ *  Copyright (C) 2015-2019 47 Degrees, LLC. <http://www.47deg.com>
+ *
  */
 
 package fpinscalalib.customlib.parsing
@@ -200,7 +201,7 @@ case class Location(input: String, offset: Int = 0) {
 
   /* Returns the line corresponding to this location */
   def currentLine: String =
-    if (input.length > 1) input.lines.drop(line - 1).next
+    if (input.length > 1) input.linesIterator.drop(line - 1).next
     else ""
 
   def columnCaret = (" " * (col - 1)) + "^"

--- a/src/main/scala/fpinscalalib/customlib/parsing/Reference.scala
+++ b/src/main/scala/fpinscalalib/customlib/parsing/Reference.scala
@@ -1,6 +1,7 @@
 /*
- * scala-exercises - exercises-fpinscala
- * Copyright (C) 2015-2016 47 Degrees, LLC. <http://www.47deg.com>
+ *  scala-exercises - exercises-fpinscala
+ *  Copyright (C) 2015-2019 47 Degrees, LLC. <http://www.47deg.com>
+ *
  */
 
 package fpinscalalib.customlib.parsing
@@ -151,8 +152,7 @@ object Reference extends Parsers[Parser] {
    */
   override def many[A](p: Parser[A]): Parser[List[A]] =
     s => {
-      var nConsumed: Int = 0
-      val buf            = new collection.mutable.ListBuffer[A]
+      val buf = new collection.mutable.ListBuffer[A]
       def go(p: Parser[A], offset: Int): Result[List[A]] = {
         p(s.advanceBy(offset)) match {
           case Success(a, n)        => buf += a; go(p, offset + n)

--- a/src/main/scala/fpinscalalib/customlib/state/StateHelper.scala
+++ b/src/main/scala/fpinscalalib/customlib/state/StateHelper.scala
@@ -1,6 +1,7 @@
 /*
- * scala-exercises - exercises-fpinscala
- * Copyright (C) 2015-2016 47 Degrees, LLC. <http://www.47deg.com>
+ *  scala-exercises - exercises-fpinscala
+ *  Copyright (C) 2015-2019 47 Degrees, LLC. <http://www.47deg.com>
+ *
  */
 
 package fpinscalalib.customlib.state

--- a/src/main/scala/fpinscalalib/customlib/testing/GenHelper.scala
+++ b/src/main/scala/fpinscalalib/customlib/testing/GenHelper.scala
@@ -1,6 +1,7 @@
 /*
- * scala-exercises - exercises-fpinscala
- * Copyright (C) 2015-2016 47 Degrees, LLC. <http://www.47deg.com>
+ *  scala-exercises - exercises-fpinscala
+ *  Copyright (C) 2015-2019 47 Degrees, LLC. <http://www.47deg.com>
+ *
  */
 
 package fpinscalalib.customlib.testing

--- a/src/test/scala/fpinscalalib/ErrorHandlingSpec.scala
+++ b/src/test/scala/fpinscalalib/ErrorHandlingSpec.scala
@@ -1,42 +1,43 @@
 /*
- * scala-exercises - exercises-fpinscala
- * Copyright (C) 2015-2016 47 Degrees, LLC. <http://www.47deg.com>
+ *  scala-exercises - exercises-fpinscala
+ *  Copyright (C) 2015-2019 47 Degrees, LLC. <http://www.47deg.com>
+ *
  */
 
 package fpinscalalib
 
-import org.scalacheck.Shapeless._
+import org.scalacheck.ScalacheckShapeless._
 import org.scalaexercises.Test
-import org.scalatest.Spec
-import org.scalatest.prop.Checkers
+import org.scalatest.refspec.RefSpec
+import org.scalatestplus.scalacheck.Checkers
 import shapeless.HNil
 import fpinscalalib.customlib.errorhandling._
 import fpinscalalib.customlib.errorhandling.Employee
 import fpinscalalib.customlib.errorhandling.ExampleHelper._
 import org.scalacheck.{Arbitrary, Gen}
 
-class ErrorHandlingSpec extends Spec with Checkers {
+class ErrorHandlingSpec extends RefSpec with Checkers {
 
-  def `option map asserts` = {
+  def `option map asserts`() = {
     val f = (e: Option[Employee]) => e.map(_.department)
 
     check(Test.testSuccess(ErrorHandlingSection.optionMapAssert _, f :: HNil))
   }
 
-  def `option flatMap asserts` = {
+  def `option flatMap asserts`() = {
     val f = (e: Option[Employee]) => e.flatMap(_.manager)
 
     check(Test.testSuccess(ErrorHandlingSection.optionFlatMapAssert _, f :: HNil))
   }
 
-  def `option orElse asserts` = {
+  def `option orElse asserts`() = {
     check(
       Test.testSuccess(
         ErrorHandlingSection.optionOrElseAssert _,
         Some("Julie") :: Some("Mr. CEO") :: Some("Mr. CEO") :: HNil))
   }
 
-  def `option filter asserts` = {
+  def `option filter asserts`() = {
 
     implicit def optionArbitrary[T](implicit GT: Gen[T]): Arbitrary[Option[T]] = Arbitrary {
       Gen.option[T](GT) map {
@@ -59,7 +60,7 @@ class ErrorHandlingSpec extends Spec with Checkers {
         .testSuccess(ErrorHandlingSection.optionFilterAssert _, Some(joe) :: none :: none :: HNil))
   }
 
-  def `option sequence asserts` = {
+  def `option sequence asserts`() = {
     val none: Option[List[Int]] = None
     check(
       Test.testSuccess(
@@ -67,7 +68,7 @@ class ErrorHandlingSpec extends Spec with Checkers {
         Some(List(1, 2, 3)) :: none :: HNil))
   }
 
-  def `option traverse asserts` = {
+  def `option traverse asserts`() = {
     val none: Option[List[Int]] = None
     check(
       Test.testSuccess(
@@ -75,34 +76,34 @@ class ErrorHandlingSpec extends Spec with Checkers {
         Some(List(1, 2, 3)) :: none :: HNil))
   }
 
-  def `either map asserts` = {
+  def `either map asserts`() = {
     val f = (e: Either[String, Employee]) => e.map(_.department)
 
     check(Test.testSuccess(ErrorHandlingSection.eitherMapAssert _, f :: HNil))
   }
 
-  def `either flatMap asserts` = {
+  def `either flatMap asserts`() = {
     check(
       Test.testSuccess(
         ErrorHandlingSection.eitherFlatMapAssert _,
         Right("Julie") :: Left("Manager not found") :: Left("Employee not found") :: HNil))
   }
 
-  def `either orElse asserts` = {
+  def `either orElse asserts`() = {
     check(
       Test.testSuccess(
         ErrorHandlingSection.eitherOrElseAssert _,
         Right("Julie") :: Right("Mr. CEO") :: Right("Mr. CEO") :: HNil))
   }
 
-  def `either map2 asserts` = {
+  def `either map2 asserts`() = {
     check(
       Test.testSuccess(
         ErrorHandlingSection.eitherMap2Assert _,
         Right(false) :: Right(true) :: Left("Employee not found") :: HNil))
   }
 
-  def `either traverse asserts` = {
+  def `either traverse asserts`() = {
     val list = List(joe, mary)
     check(
       Test.testSuccess(
@@ -110,7 +111,7 @@ class ErrorHandlingSpec extends Spec with Checkers {
         Right(list) :: Left("Employee not found") :: HNil))
   }
 
-  def `either sequence asserts` = {
+  def `either sequence asserts`() = {
     val list = List(joe, mary)
     check(
       Test.testSuccess(

--- a/src/test/scala/fpinscalalib/FunctionalDataStructuresSpec.scala
+++ b/src/test/scala/fpinscalalib/FunctionalDataStructuresSpec.scala
@@ -1,6 +1,7 @@
 /*
- * scala-exercises - exercises-fpinscala
- * Copyright (C) 2015-2016 47 Degrees, LLC. <http://www.47deg.com>
+ *  scala-exercises - exercises-fpinscala
+ *  Copyright (C) 2015-2019 47 Degrees, LLC. <http://www.47deg.com>
+ *
  */
 
 package fpinscalalib
@@ -9,123 +10,121 @@ import fpinscalalib.customlib.functionaldatastructures.{Branch, Leaf, _}
 import org.scalacheck.Arbitrary
 import org.scalacheck.Arbitrary.arbitrary
 import org.scalacheck.Gen.{const, frequency, resize, sized}
-import org.scalacheck.Shapeless._
+import org.scalacheck.ScalacheckShapeless._
 import org.scalaexercises.Test
-import org.scalatest.Spec
-import org.scalatest.prop.Checkers
+import org.scalatest.refspec.RefSpec
+import org.scalatestplus.scalacheck.Checkers
 import shapeless.HNil
 
-class FunctionalDataStructuresSpec extends Spec with Checkers {
+class FunctionalDataStructuresSpec extends RefSpec with Checkers {
 
-  implicit def arbListArbitrary[T](implicit a: Arbitrary[T]): Arbitrary[List[T]] = {
-    Arbitrary(
-      sized(n => frequency((n, resize(n / 2, arbitrary[T]).map(List(_))), (1, const(Nil)))))
-  }
+  implicit def arbListArbitrary[T](implicit a: Arbitrary[T]): Arbitrary[List[T]] =
+    Arbitrary(sized(n => frequency((n, resize(n / 2, arbitrary[T]).map(List(_))), (1, const(Nil)))))
 
-  def `complex pattern matching asserts` =
+  def `complex pattern matching asserts`() =
     check(Test.testSuccess(FunctionalDataStructuresSection.complexPatternAssert _, 3 :: HNil))
 
-  def `list take asserts` =
+  def `list take asserts`() =
     check(
       Test.testSuccess(
         FunctionalDataStructuresSection.listTakeAssert _,
         List(2, 3) :: List[Int]() :: HNil))
 
-  def `list setHead asserts` =
+  def `list setHead asserts`() =
     check(
       Test.testSuccess(
         FunctionalDataStructuresSection.listSetHeadAssert _,
         List(3, 2, 3) :: List("c", "b") :: HNil))
 
-  def `list drop asserts` = {
+  def `list drop asserts`() = {
     check(
       Test.testSuccess(
         FunctionalDataStructuresSection.listDropAssert _,
         List(2, 3) :: List(1, 2, 3) :: List[Int]() :: List[Int]() :: List[Int]() :: HNil))
   }
 
-  def `list dropWhile asserts` = {
+  def `list dropWhile asserts`() = {
     check(
       Test.testSuccess(
         FunctionalDataStructuresSection.listDropWhileAssert _,
         List(2, 3) :: List(1, 2, 3) :: List[Int]() :: List[Int]() :: HNil))
   }
 
-  def `list init asserts` = {
+  def `list init asserts`() = {
     check(
       Test.testSuccess(
         FunctionalDataStructuresSection.listInitAssert _,
         List(1, 2) :: List[Int]() :: HNil))
   }
 
-  def `list foldRight sum asserts` = {
+  def `list foldRight sum asserts`() = {
     check(
       Test.testSuccess(
         FunctionalDataStructuresSection.listFoldRightSumAssert _,
         1 :: 1 :: 2 :: 1 :: 2 :: 3 :: List[Int]() :: 1 :: 2 :: 3 :: 0 :: HNil))
   }
 
-  def `list foldRight cons nil asserts` =
+  def `list foldRight cons nil asserts`() =
     check(
       Test.testSuccess(
         FunctionalDataStructuresSection.listFoldRightNilConsAssert _,
         List(1, 2, 3) :: HNil))
 
-  def `list length with foldRight asserts` =
+  def `list length with foldRight asserts`() =
     check(Test.testSuccess(FunctionalDataStructuresSection.listLengthAssert _, 0 :: 1 :: HNil))
 
-  def `list foldLeft sum product length asserts` =
+  def `list foldLeft sum product length asserts`() =
     check(
       Test.testSuccess(
         FunctionalDataStructuresSection.listFoldLeftSumProductLengthAssert _,
         0 :: 1.0 :: 0 :: 1 :: HNil))
 
-  def `list foldLeft append asserts` = {
+  def `list foldLeft append asserts`() = {
     check(
       Test.testSuccess(
         FunctionalDataStructuresSection.listAppendAssert _,
         List(1, 2, 3, 1, 2) :: List(1, 2, 3) :: List(1, 2) :: List[Int]() :: HNil))
   }
 
-  def `list add 1 asserts` =
+  def `list add 1 asserts`() =
     check(Test.testSuccess(FunctionalDataStructuresSection.listAdd1Assert _, 1 :: HNil))
 
-  def `list remove odds asserts` =
+  def `list remove odds asserts`() =
     check(Test.testSuccess(FunctionalDataStructuresSection.listRemoveOdds _, 2 :: 0 :: HNil))
 
-  def `list flatMap asserts` =
+  def `list flatMap asserts`() =
     check(
       Test.testSuccess(
         FunctionalDataStructuresSection.listFlatMapAssert _,
         List(1, 1, 2, 2, 3, 3) :: HNil))
 
-  def `list zipWith asserts` = {
+  def `list zipWith asserts`() = {
     check(
       Test.testSuccess(
         FunctionalDataStructuresSection.listZipWithAssert _,
         List("aA", "bB", "cC") :: List("14", "25", "36") :: HNil))
   }
 
-  def `list hasSubsequence asserts` =
+  def `list hasSubsequence asserts`() =
     check(
       Test.testSuccess(
         FunctionalDataStructuresSection.listHasSubsequenceAssert _,
         true :: false :: true :: HNil))
 
-  def `tree size asserts` =
+  def `tree size asserts`() =
     check(Test.testSuccess(FunctionalDataStructuresSection.treeSizeAssert _, 1 :: 1 :: HNil))
 
-  def `tree depth asserts` =
+  def `tree depth asserts`() =
     check(Test.testSuccess(FunctionalDataStructuresSection.treeDepthAssert _, 0 :: 1 :: HNil))
 
-  def `tree map asserts` = {
+  def `tree map asserts`() = {
     check(
       Test.testSuccess(
         FunctionalDataStructuresSection.treeMapAssert _,
         Branch[Int](Branch[Int](Leaf[Int](2), Leaf[Int](4)), Leaf[Int](6)) :: HNil))
   }
 
-  def `tree fold asserts` = {
+  def `tree fold asserts`() = {
     check(
       Test.testSuccess(
         FunctionalDataStructuresSection.treeFoldAssert _,

--- a/src/test/scala/fpinscalalib/FunctionalParalellismSpec.scala
+++ b/src/test/scala/fpinscalalib/FunctionalParalellismSpec.scala
@@ -1,39 +1,39 @@
 /*
- * scala-exercises - exercises-fpinscala
- * Copyright (C) 2015-2016 47 Degrees, LLC. <http://www.47deg.com>
+ *  scala-exercises - exercises-fpinscala
+ *  Copyright (C) 2015-2019 47 Degrees, LLC. <http://www.47deg.com>
+ *
  */
 
 package fpinscalalib
 
 import org.scalaexercises.Test
-import org.scalatest.Spec
-import org.scalatest.prop.Checkers
-import org.scalacheck.Shapeless._
-import org.scalacheck.{Arbitrary, Gen}
+import org.scalatest.refspec.RefSpec
+import org.scalatestplus.scalacheck.Checkers
+import org.scalacheck.ScalacheckShapeless._
 import shapeless.HNil
 
-class FunctionalParalellismSpec extends Spec with Checkers {
-  def `par asyncF asserts` =
+class FunctionalParalellismSpec extends RefSpec with Checkers {
+  def `par asyncF asserts`() =
     check(Test.testSuccess(FunctionalParallelismSection.parAsyncFAssert _, "10" :: HNil))
 
-  def `par filter asserts` =
+  def `par filter asserts`() =
     FunctionalParallelismSection.parFilterAssert(List(1, 2, 3))
 
-  def `par choiceN asserts` =
+  def `par choiceN asserts`() =
     FunctionalParallelismSection.parChoiceNAssert(1)
 
-  def `par choiceMap asserts` =
+  def `par choiceMap asserts`() =
     FunctionalParallelismSection.parChoiceMapAssert(2)
 
-  def `par chooser asserts` =
+  def `par chooser asserts`() =
     FunctionalParallelismSection.parChooserAssert("odd")
 
-  def `par choice via flatMap asserts` =
+  def `par choice via flatMap asserts`() =
     FunctionalParallelismSection.parChoiceViaFlatMapAssert("a")
 
-  def `par choiceN via flatMap asserts` =
+  def `par choiceN via flatMap asserts`() =
     FunctionalParallelismSection.parChoiceNViaFlatMapAssert("c")
 
-  def `par flatMap and join asserts` =
+  def `par flatMap and join asserts`() =
     FunctionalParallelismSection.parFlatMapJoinAssert("foo")
 }

--- a/src/test/scala/fpinscalalib/FunctionalStateSpec.scala
+++ b/src/test/scala/fpinscalalib/FunctionalStateSpec.scala
@@ -1,36 +1,33 @@
 /*
- * scala-exercises - exercises-fpinscala
- * Copyright (C) 2015-2016 47 Degrees, LLC. <http://www.47deg.com>
+ *  scala-exercises - exercises-fpinscala
+ *  Copyright (C) 2015-2019 47 Degrees, LLC. <http://www.47deg.com>
+ *
  */
 
 package fpinscalalib
 
-import org.scalacheck.Shapeless._
-import org.scalacheck.{Arbitrary, Gen}
-import org.scalaexercises.Test
-import org.scalatest.Spec
-import org.scalatest.prop.Checkers
-import shapeless.HNil
+import org.scalatest.refspec.RefSpec
+import org.scalatestplus.scalacheck.Checkers
 
-class FunctionalStateSpec extends Spec with Checkers {
-  def `random non-negative integers asserts` =
+class FunctionalStateSpec extends RefSpec with Checkers {
+  def `random non-negative integers asserts`() =
     FunctionalStateSection.randomNonNegativeIntAssert(0, 1)
 
-  def `random doubles asserts` =
+  def `random doubles asserts`() =
     FunctionalStateSection.randomDoubleAssert(1)
 
-  def `random integers list asserts` =
+  def `random integers list asserts`() =
     FunctionalStateSection.randomIntListAssert(0, 1)
 
-  def `random doubles via map asserts` =
+  def `random doubles via map asserts`() =
     FunctionalStateSection.randomDoubleViaMap(1)
 
-  def `random non negative less than asserts` =
+  def `random non negative less than asserts`() =
     FunctionalStateSection.randomNonNegativeLessThan(1, 0)
 
-  def `random roll die asserts` =
+  def `random roll die asserts`() =
     FunctionalStateSection.randomRollDie(1)
 
-  def `candy machine asserts` =
+  def `candy machine asserts`() =
     FunctionalStateSection.candyMachineAssert(1, 1)
 }

--- a/src/test/scala/fpinscalalib/GettingStartedWithFPSpec.scala
+++ b/src/test/scala/fpinscalalib/GettingStartedWithFPSpec.scala
@@ -13,8 +13,8 @@ import org.scalatestplus.scalacheck.Checkers
 import shapeless.HNil
 
 class GettingStartedWithFPSpec extends RefSpec with Checkers {
-  def `fibonacci asserts`() =
-    check(Test.testSuccess(GettingStartedWithFPSection.fibAssert _, 0 :: 1 :: HNil))
+  //def `fibonacci asserts`() =
+  //  check(Test.testSuccess(GettingStartedWithFPSection.fibAssert _, 0 :: 1 :: HNil))
 
   def `isSorted asserts`() =
     check(

--- a/src/test/scala/fpinscalalib/GettingStartedWithFPSpec.scala
+++ b/src/test/scala/fpinscalalib/GettingStartedWithFPSpec.scala
@@ -1,34 +1,32 @@
 /*
- * scala-exercises - exercises-fpinscala
- * Copyright (C) 2015-2016 47 Degrees, LLC. <http://www.47deg.com>
+ *  scala-exercises - exercises-fpinscala
+ *  Copyright (C) 2015-2019 47 Degrees, LLC. <http://www.47deg.com>
+ *
  */
 
 package fpinscalalib
 
-import org.scalacheck.Shapeless._
-import org.scalacheck.{Arbitrary, Gen}
+import org.scalacheck.ScalacheckShapeless._
 import org.scalaexercises.Test
-import org.scalatest.Spec
-import org.scalatest.prop.Checkers
+import org.scalatest.refspec.RefSpec
+import org.scalatestplus.scalacheck.Checkers
 import shapeless.HNil
 
-class GettingStartedWithFPSpec extends Spec with Checkers {
-  def `fibonacci asserts` = {
-    implicit val intArbitrary = Arbitrary[Int](Gen.choose(1, 100))
+class GettingStartedWithFPSpec extends RefSpec with Checkers {
+  def `fibonacci asserts`() =
     check(Test.testSuccess(GettingStartedWithFPSection.fibAssert _, 0 :: 1 :: HNil))
-  }
 
-  def `isSorted asserts` =
+  def `isSorted asserts`() =
     check(
       Test
         .testSuccess(GettingStartedWithFPSection.isSortedAssert _, true :: false :: true :: HNil))
 
-  def `currying asserts` =
+  def `currying asserts`() =
     check(Test.testSuccess(GettingStartedWithFPSection.curryAssert _, true :: true :: HNil))
 
-  def `uncurrying asserts` =
+  def `uncurrying asserts`() =
     check(Test.testSuccess(GettingStartedWithFPSection.uncurryAssert _, true :: true :: HNil))
 
-  def `composing asserts` =
+  def `composing asserts`() =
     check(Test.testSuccess(GettingStartedWithFPSection.composeAssert _, false :: 2 :: 3 :: HNil))
 }

--- a/src/test/scala/fpinscalalib/GettingStartedWithFPSpec.scala
+++ b/src/test/scala/fpinscalalib/GettingStartedWithFPSpec.scala
@@ -7,14 +7,24 @@
 package fpinscalalib
 
 import org.scalacheck.ScalacheckShapeless._
+import org.scalacheck.{Arbitrary, Gen}
 import org.scalaexercises.Test
 import org.scalatest.refspec.RefSpec
 import org.scalatestplus.scalacheck.Checkers
-import shapeless.HNil
+import shapeless._
 
 class GettingStartedWithFPSpec extends RefSpec with Checkers {
-  //def `fibonacci asserts`() =
-  //  check(Test.testSuccess(GettingStartedWithFPSection.fibAssert _, 0 :: 1 :: HNil))
+
+  def `fibonacci asserts`() = {
+    implicit val arb = Arbitrary {
+      for {
+        res0 <- Gen.choose(2, 10)
+        res1 <- Gen.choose(2, 10)
+      } yield res0 :: res1 :: HNil
+    }
+
+    check(Test.testSuccess(GettingStartedWithFPSection.fibAssert _, 0 :: 1 :: HNil))
+  }
 
   def `isSorted asserts`() =
     check(

--- a/src/test/scala/fpinscalalib/ParserCombinatorsSpec.scala
+++ b/src/test/scala/fpinscalalib/ParserCombinatorsSpec.scala
@@ -1,38 +1,39 @@
 /*
- * scala-exercises - exercises-fpinscala
- * Copyright (C) 2015-2016 47 Degrees, LLC. <http://www.47deg.com>
+ *  scala-exercises - exercises-fpinscala
+ *  Copyright (C) 2015-2019 47 Degrees, LLC. <http://www.47deg.com>
+ *
  */
 
 package fpinscalalib
 
-import org.scalatest.Spec
-import org.scalatest.prop.Checkers
-import org.scalacheck.Shapeless._
+import org.scalatest.refspec.RefSpec
+import org.scalatestplus.scalacheck.Checkers
+import org.scalacheck.ScalacheckShapeless._
 import org.scalaexercises.Test
 import shapeless.HNil
 
-class ParserCombinatorsSpec extends Spec with Checkers {
-  def `parser many1 asserts` =
+class ParserCombinatorsSpec extends RefSpec with Checkers {
+  def `parser many1 asserts`() =
     ParserCombinatorsSection.parserMany1Assert("a", "aaa")
 
-  def `parser many asserts` =
+  def `parser many asserts`() =
     ParserCombinatorsSection.parserManyAssert(Right(List()), Right(List('a', 'a', 'a')))
 
-  def `parser listOfN asserts` =
+  def `parser listOfN asserts`() =
     ParserCombinatorsSection.parserListOfNAssert(0, 1)
 
-  def `parser flatMap asserts` =
+  def `parser flatMap asserts`() =
     ParserCombinatorsSection.parseFlatMapAssert("[0-9]+")
 
-  def `parser string asserts` =
+  def `parser string asserts`() =
     check(Test.testSuccess(ParserCombinatorsSection.parserStringAssert _, "42" :: HNil))
 
-  def `parser regex asserts` =
+  def `parser regex asserts`() =
     ParserCombinatorsSection.parserRegexAssert("[0-9]+")
 
-  def `parser slice asserts` =
+  def `parser slice asserts`() =
     check(Test.testSuccess(ParserCombinatorsSection.parserSliceAssert _, true :: HNil))
 
-  def `parser json asserts` =
+  def `parser json asserts`() =
     check(Test.testSuccess(ParserCombinatorsSection.parserJSONAssert _, "[]" :: HNil))
 }

--- a/src/test/scala/fpinscalalib/PropertyBasedTestingSpec.scala
+++ b/src/test/scala/fpinscalalib/PropertyBasedTestingSpec.scala
@@ -1,49 +1,48 @@
 /*
- * scala-exercises - exercises-fpinscala
- * Copyright (C) 2015-2016 47 Degrees, LLC. <http://www.47deg.com>
+ *  scala-exercises - exercises-fpinscala
+ *  Copyright (C) 2015-2019 47 Degrees, LLC. <http://www.47deg.com>
+ *
  */
 
 package fpinscalalib
 
-import fpinscalalib.customlib.testing.Prop
-import fpinscalalib.customlib.testing.Prop.{Falsified, Passed, Result}
-import org.scalacheck.{Arbitrary, Gen}
+import fpinscalalib.customlib.testing.Prop.Passed
 import org.scalaexercises.Test
-import org.scalacheck.Shapeless._
-import org.scalatest.Spec
-import org.scalatest.prop.Checkers
+import org.scalacheck.ScalacheckShapeless._
+import org.scalatest.refspec.RefSpec
+import org.scalatestplus.scalacheck.Checkers
 import shapeless.HNil
 
-class PropertyBasedTestingSpec extends Spec with Checkers {
+class PropertyBasedTestingSpec extends RefSpec with Checkers {
 
-  def `prop and asserts` =
+  def `prop and asserts`() =
     check(Test.testSuccess(PropertyBasedTestingSection.propAndAssert _, 4 :: 4 :: true :: HNil))
 
-  def `gen choose int` =
+  def `gen choose int`() =
     PropertyBasedTestingSection.genChooseIntAssert(0, 0, 10, 10)
 
-  def `gen unit` =
+  def `gen unit`() =
     check(Test.testSuccess(PropertyBasedTestingSection.genUnitAssert _, 42 :: "foo" :: HNil))
 
-  def `gen listOfN` =
+  def `gen listOfN`() =
     check(
       Test.testSuccess(PropertyBasedTestingSection.genListOfN _, 10 :: List(42, 42, 42) :: HNil))
 
-  def `gen listOfN via flatMap` =
+  def `gen listOfN via flatMap`() =
     check(
       Test.testSuccess(
         PropertyBasedTestingSection.genListOfNViaFlatMap _,
         0 :: 10 :: List(42) :: HNil))
 
-  def `prop and or` =
+  def `prop and or`() =
     PropertyBasedTestingSection.propAndOrAssert(Passed)
 
-  def `sgen listOf` =
+  def `sgen listOf`() =
     check(Test.testSuccess(PropertyBasedTestingSection.sGenListOfAssert _, 42 :: HNil))
 
-  def `sgen listOf1` =
+  def `sgen listOf1`() =
     PropertyBasedTestingSection.sGenListOf1(1)
 
-  def `prop takeWhile dropWhile` =
+  def `prop takeWhile dropWhile`() =
     PropertyBasedTestingSection.propTakeWhileDropWhile(Passed)
 }

--- a/src/test/scala/fpinscalalib/StrictnessAndLazinessSpec.scala
+++ b/src/test/scala/fpinscalalib/StrictnessAndLazinessSpec.scala
@@ -1,83 +1,83 @@
 /*
- * scala-exercises - exercises-fpinscala
- * Copyright (C) 2015-2016 47 Degrees, LLC. <http://www.47deg.com>
+ *  scala-exercises - exercises-fpinscala
+ *  Copyright (C) 2015-2019 47 Degrees, LLC. <http://www.47deg.com>
+ *
  */
 
 package fpinscalalib
 
 import fpinscalalib.customlib.laziness.Stream
-import org.scalacheck.Shapeless._
+import org.scalacheck.ScalacheckShapeless._
 import org.scalacheck.{Arbitrary, Gen}
 import org.scalaexercises.Test
-import org.scalatest.Spec
-import org.scalatest.prop.Checkers
+import org.scalatest.refspec.RefSpec
+import org.scalatestplus.scalacheck.Checkers
 import shapeless.HNil
 
-class StrictnessAndLazinessSpec extends Spec with Checkers {
+class StrictnessAndLazinessSpec extends RefSpec with Checkers {
   import Gen.{const, frequency, resize, sized}
   import Arbitrary._
 
-  implicit def arbStreamAlternative[T](implicit a: Arbitrary[T]): Arbitrary[Stream[T]] = {
+  implicit def arbStreamAlternative[T](implicit a: Arbitrary[T]): Arbitrary[Stream[T]] =
     Arbitrary(sized(n =>
       frequency((n, resize(n / 2, arbitrary[T]).map(Stream(_))), (1, const(Stream.empty)))))
-  }
 
-  def `stream toList asserts` =
+  def `stream toList asserts`() =
     check(
       Test.testSuccess(StrictnessAndLazinessSection.streamToListAssert _, List(1, 2, 3) :: HNil))
 
-  def `stream take asserts` =
+  def `stream take asserts`() =
     check(Test.testSuccess(StrictnessAndLazinessSection.streamTakeAssert _, 1 :: HNil))
 
-  def `stream drop asserts` =
+  def `stream drop asserts`() =
     check(Test.testSuccess(StrictnessAndLazinessSection.streamDropAssert _, 1 :: HNil))
 
-  def `stream takeWhile asserts` =
+  def `stream takeWhile asserts`() =
     check(
       Test.testSuccess(
         StrictnessAndLazinessSection.streamTakeWhileAssert _,
         List(1, 2) :: List[Int]() :: HNil))
 
-  def `stream forAll asserts` =
+  def `stream forAll asserts`() =
     check(Test.testSuccess(StrictnessAndLazinessSection.streamForAllAssert _, true :: HNil))
 
-  def `stream trace asserts` = {
+  def `stream trace asserts`() = {
     check(
       Test.testSuccess(
         StrictnessAndLazinessSection.streamTraceAssert _,
         11 :: Stream(2, 3, 4) :: Stream(3, 4) :: 13 :: Stream(4) :: 14 :: HNil))
   }
 
-  def `stream ones asserts` = {
+  def `stream ones asserts`() = {
     check(
       Test.testSuccess(
         StrictnessAndLazinessSection.streamOnesAssert _,
         List(1, 1, 1, 1, 1) :: true :: true :: false :: HNil))
   }
 
-  def `stream integers asserts` =
+  def `stream integers asserts`() =
     check(Test.testSuccess(StrictnessAndLazinessSection.streamIntegersAssert _, 1 :: HNil))
 
-  def `stream fibs asserts` =
+  def `stream fibs asserts`() =
     check(Test.testSuccess(StrictnessAndLazinessSection.streamFibsAssert _, 0 :: 1 :: HNil))
 
-  def `stream fibs via unfold asserts` =
+  def `stream fibs via unfold asserts`() =
     check(
       Test.testSuccess(StrictnessAndLazinessSection.streamFibsViaUnfoldAssert _, 0 :: 1 :: HNil))
 
-  def `stream integers via unfold asserts` =
+  def `stream integers via unfold asserts`() =
     check(Test.testSuccess(StrictnessAndLazinessSection.streamIntegersAssert _, 1 :: HNil))
 
-  def `stream ones via unfold asserts` =
-    StrictnessAndLazinessSection.streamOnesViaUnfoldAssert(Some(1, 1))
+  def `stream ones via unfold asserts`() =
+    StrictnessAndLazinessSection.streamOnesViaUnfoldAssert(Some((1, 1)))
 
-  def `stream take via unfold asserts` =
+  def `stream take via unfold asserts`() =
     StrictnessAndLazinessSection.streamTakeViaUnfold(0, 1)
 
-  def `stream tails asserts` =
+  def `stream tails asserts`() =
     StrictnessAndLazinessSection.streamTailsAssert(1)
 
-  def `stream scanRight asserts` =
+  def `stream scanRight asserts`() =
     check(
       Test.testSuccess(
         StrictnessAndLazinessSection.streamScanRightAssert _,

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.4.2-SNAPSHOT"
+version in ThisBuild := "0.5.0-SNAPSHOT"


### PR DESCRIPTION
This PR updates the library to Scala 2.12.10 and its dependencies. Added compatibility with Scala Exercises 0.5.0-SNAPSHOT