### PR TITLE
Updated ScalaTest 3.1.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -13,7 +13,8 @@ lazy val fpinscala = (project in file("."))
       %%("shapeless", V.shapeless),
       %%("scalatest", V.scalatest),
       %%("scalacheck", V.scalacheck),
-      "com.github.alexarchambault" %% "scalacheck-shapeless_1.14" % V.scalacheckShapeless
+      "com.github.alexarchambault" %% "scalacheck-shapeless_1.14" % V.scalacheckShapeless,
+      "org.scalatestplus"          %% "scalatestplus-scalacheck"  % V.scalatestplusScheck
     )
   )
 

--- a/project/ProjectPlugin.scala
+++ b/project/ProjectPlugin.scala
@@ -17,7 +17,8 @@ object ProjectPlugin extends AutoPlugin {
     lazy val V = new {
       val scala212: String            = "2.12.10"
       val shapeless: String           = "2.3.3"
-      val scalatest: String           = "3.0.8"
+      val scalatest: String           = "3.1.0"
+      val scalatestplusScheck: String = "3.1.0.0-RC2"
       val scalacheck: String          = "1.14.2"
       val scalacheckShapeless: String = "1.2.3"
     }

--- a/src/main/scala/fpinscalalib/ErrorHandlingSection.scala
+++ b/src/main/scala/fpinscalalib/ErrorHandlingSection.scala
@@ -9,14 +9,15 @@ package fpinscalalib
 import fpinscalalib.customlib.errorhandling._
 import fpinscalalib.customlib.errorhandling.Option._
 import fpinscalalib.customlib.errorhandling.ExampleHelper._
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
 import scala.util.{Success, Try}
 
 /** @param name handling_error_without_exceptions
  */
 object ErrorHandlingSection
-    extends FlatSpec
+    extends AnyFlatSpec
     with Matchers
     with org.scalaexercises.definitions.Section {
 

--- a/src/main/scala/fpinscalalib/FunctionalDataStructuresSection.scala
+++ b/src/main/scala/fpinscalalib/FunctionalDataStructuresSection.scala
@@ -6,7 +6,8 @@
 
 package fpinscalalib
 
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 import fpinscalalib.customlib.functionaldatastructures._
 import fpinscalalib.customlib.functionaldatastructures.List._
 import Tree._
@@ -14,7 +15,7 @@ import Tree._
 /** @param name functional_data_structures
  */
 object FunctionalDataStructuresSection
-    extends FlatSpec
+    extends AnyFlatSpec
     with Matchers
     with org.scalaexercises.definitions.Section {
 

--- a/src/main/scala/fpinscalalib/FunctionalParallelismSection.scala
+++ b/src/main/scala/fpinscalalib/FunctionalParallelismSection.scala
@@ -8,13 +8,14 @@ package fpinscalalib
 
 import fpinscalalib.customlib.functionalparallelism.Par
 import fpinscalalib.customlib.functionalparallelism.Par._
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 import java.util.concurrent.Executors
 
 /** @param name purely_functional_parallelism
  */
 object FunctionalParallelismSection
-    extends FlatSpec
+    extends AnyFlatSpec
     with Matchers
     with org.scalaexercises.definitions.Section {
 

--- a/src/main/scala/fpinscalalib/FunctionalStateSection.scala
+++ b/src/main/scala/fpinscalalib/FunctionalStateSection.scala
@@ -8,13 +8,14 @@ package fpinscalalib
 
 import fpinscalalib.customlib.state.RNG.Simple
 import fpinscalalib.customlib.state.RNG._
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 import fpinscalalib.customlib.state._
 
 /** @param name pure_functional_state
  */
 object FunctionalStateSection
-    extends FlatSpec
+    extends AnyFlatSpec
     with Matchers
     with org.scalaexercises.definitions.Section {
 

--- a/src/main/scala/fpinscalalib/GettingStartedWithFPSection.scala
+++ b/src/main/scala/fpinscalalib/GettingStartedWithFPSection.scala
@@ -6,12 +6,13 @@
 
 package fpinscalalib
 
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
 /** @param name getting_started_with_functional_programming
  */
 object GettingStartedWithFPSection
-    extends FlatSpec
+    extends AnyFlatSpec
     with Matchers
     with org.scalaexercises.definitions.Section {
 

--- a/src/main/scala/fpinscalalib/ParserCombinatorsSection.scala
+++ b/src/main/scala/fpinscalalib/ParserCombinatorsSection.scala
@@ -6,7 +6,8 @@
 
 package fpinscalalib
 
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 import fpinscalalib.customlib.parsing.{JSON, ParseError, Reference}
 import fpinscalalib.customlib.parsing.ReferenceTypes._
 import Reference._
@@ -15,7 +16,7 @@ import scala.util.matching.Regex
 /** @param name parser_combinatorss
  */
 object ParserCombinatorsSection
-    extends FlatSpec
+    extends AnyFlatSpec
     with Matchers
     with org.scalaexercises.definitions.Section
     with ReferenceHelper {

--- a/src/main/scala/fpinscalalib/PropertyBasedTestingSection.scala
+++ b/src/main/scala/fpinscalalib/PropertyBasedTestingSection.scala
@@ -7,7 +7,8 @@
 package fpinscalalib
 
 import fpinscalalib.customlib.state.{RNG, State}
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 import fpinscalalib.customlib.testing.{Gen, SGen}
 import fpinscalalib.customlib.testing.Gen._
 import fpinscalalib.customlib.testing.Prop._
@@ -15,7 +16,7 @@ import fpinscalalib.customlib.testing.Prop._
 /** @param name property_based_testing
  */
 object PropertyBasedTestingSection
-    extends FlatSpec
+    extends AnyFlatSpec
     with Matchers
     with org.scalaexercises.definitions.Section {
 

--- a/src/main/scala/fpinscalalib/StrictnessAndLazinessSection.scala
+++ b/src/main/scala/fpinscalalib/StrictnessAndLazinessSection.scala
@@ -9,12 +9,13 @@ package fpinscalalib
 import fpinscalalib.customlib.laziness._
 import fpinscalalib.customlib.laziness.Stream
 import fpinscalalib.customlib.laziness.Stream._
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
 /** @param name strictness_and_laziness
  */
 object StrictnessAndLazinessSection
-    extends FlatSpec
+    extends AnyFlatSpec
     with Matchers
     with org.scalaexercises.definitions.Section {
 


### PR DESCRIPTION
This PR updates ScalaTest version to 3.1.0.