### PR TITLE
Fix exercise 8.9 function name from "\\" to "||"

### DIFF
--- a/src/main/scala/fpinscalalib/PropertyBasedTestingSection.scala
+++ b/src/main/scala/fpinscalalib/PropertyBasedTestingSection.scala
@@ -203,7 +203,7 @@ object PropertyBasedTestingSection
    *
    * <b>Exercise 8.9</b>
    *
-   * Let's implement `&&` and `\\` to compose `Prop` values:
+   * Let's implement `&&` and `||` to compose `Prop` values:
    *
    * {{{
    *   def &&(p: Prop) = Prop {


### PR DESCRIPTION
I just fixed a minor typo, that mentioned the `||` function, with wrong characters `\\` from property-base testing lesson, more precisely exercise 8.9.