### PR TITLE
Fix wrong exercise number for Ch. 8

### DIFF
--- a/src/main/scala/fpinscalalib/PropertyBasedTestingSection.scala
+++ b/src/main/scala/fpinscalalib/PropertyBasedTestingSection.scala
@@ -342,7 +342,7 @@ object PropertyBasedTestingSection
    *       Par.fork { Par.map2(p, Par.unit(i))(_ + _) }))
    * }}}
    *
-   * <b>Exercise 8.18</b>
+   * <b>Exercise 8.17</b>
    *
    * With `pint2` we can express the property about `fork` from chapter 7 (`fork(x) == x`):
    *


### PR DESCRIPTION
In the book, the exercise is 8.17 for expressing property about `fork` from chapter 7.
The exercise number is mistakenly duplicated.