### PR TITLE
Update to Scala 2.13.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: scala
 scala:
-- 2.12.10
+- 2.13.1
 jdk:
 - openjdk8
 script:

--- a/build.sbt
+++ b/build.sbt
@@ -1,5 +1,5 @@
 import ProjectPlugin.autoImport._
-val scalaExercisesV = "0.5.0-SNAPSHOT"
+val scalaExercisesV = "0.6.0-SNAPSHOT"
 
 def dep(artifactId: String) = "org.scala-exercises" %% artifactId % scalaExercisesV
 

--- a/project/ProjectPlugin.scala
+++ b/project/ProjectPlugin.scala
@@ -15,7 +15,7 @@ object ProjectPlugin extends AutoPlugin {
   object autoImport {
 
     lazy val V = new {
-      val scala212: String            = "2.12.10"
+      val scala213: String            = "2.13.1"
       val shapeless: String           = "2.3.3"
       val scalatest: String           = "3.1.0"
       val scalatestplusScheck: String = "3.1.0.0-RC2"
@@ -39,7 +39,7 @@ object ProjectPlugin extends AutoPlugin {
         organizationEmail = "hello@47deg.com"
       ),
       orgLicenseSetting := ApacheLicense,
-      scalaVersion := V.scala212,
+      scalaVersion := V.scala213,
       scalaOrganization := "org.scala-lang",
       resolvers ++= Seq(
         Resolver.mavenLocal,

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.2.8
+sbt.version=1.3.7

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -2,5 +2,5 @@ resolvers ++= Seq(
   Resolver.sonatypeRepo("snapshots")
 )
 
-addSbtPlugin("org.scala-exercises" % "sbt-exercise" % "0.5.0-SNAPSHOT")
+addSbtPlugin("org.scala-exercises" % "sbt-exercise" % "0.6.0-SNAPSHOT")
 addSbtPlugin("com.47deg"         % "sbt-org-policies" % "0.12.0-M3")

--- a/src/main/scala/fpinscalalib/ErrorHandlingSection.scala
+++ b/src/main/scala/fpinscalalib/ErrorHandlingSection.scala
@@ -55,17 +55,17 @@ object ErrorHandlingSection
       case _       => None
     }
 
-    /**
-     * We can look for our employees, and try to obtain their departments. We will assume that we won't find any errors,
-     * and if it's the case, we don't have to worry as the computation will end there. Try to use `map` on the result of
-     * calling `lookupByName` to create a function to obtain the department of each employee. Hint: to access the
-     * optional employee, use Scala's underscore notation. i.e.:
-     *
-     * _.getOrElse(Employee("John", "Doe", None))
-     *
-     * Employee is defined as:
-     *
-     * case class Employee(name: String, department: String, manager: Option[String])
+    /*
+     We can look for our employees, and try to obtain their departments. We will assume that we won't find any errors,
+     and if it's the case, we don't have to worry as the computation will end there. Try to use `map` on the result of
+     calling `lookupByName` to create a function to obtain the department of each employee. Hint: to access the
+     optional employee, use Scala's underscore notation. i.e.:
+
+     _.getOrElse(Employee("John", "Doe", None))
+
+     Employee is defined as:
+
+     case class Employee(name: String, department: String, manager: Option[String])
      */
     def getDepartment: (Option[Employee]) => Option[String] = res0
 
@@ -151,8 +151,8 @@ object ErrorHandlingSection
    *   def variance(xs: Seq[Double]): Option[Double] =
    *     mean(xs) flatMap (m => mean(xs.map(x => math.pow(x - m, 2))))
    * }}}
-   */
-  /**
+   *
+   *
    * <b>Exercise 4.3:</b>
    *
    * Let's write a generic function to combine two `Option` values , so that if any of those values is `None`, the

--- a/src/main/scala/fpinscalalib/FunctionalDataStructuresSection.scala
+++ b/src/main/scala/fpinscalalib/FunctionalDataStructuresSection.scala
@@ -57,7 +57,7 @@ object FunctionalDataStructuresSection
    *
    * Take a look at the implementation of `List`'s `tail` function, and check its behaviour on the following cases:
    */
-  def listTakeAssert(res0: List[Int], res1: List[Int]) {
+  def listTakeAssert(res0: List[Int], res1: List[Int]) = {
     def tail[A](l: List[A]): List[A] =
       l match {
         case Nil        => sys.error("tail of empty list")
@@ -72,7 +72,7 @@ object FunctionalDataStructuresSection
    *
    * `setHead` follows a similar principle. Let's take a look at how it works:
    */
-  def listSetHeadAssert(res0: List[Int], res1: List[String]) {
+  def listSetHeadAssert(res0: List[Int], res1: List[String]) = {
     def setHead[A](l: List[A], h: A): List[A] = l match {
       case Nil        => sys.error("setHead on empty list")
       case Cons(_, t) => Cons(h, t)
@@ -91,7 +91,7 @@ object FunctionalDataStructuresSection
       res1: List[Int],
       res2: List[Int],
       res3: List[Int],
-      res4: List[Int]) {
+      res4: List[Int]) = {
     def drop[A](l: List[A], n: Int): List[A] =
       if (n <= 0) l
       else
@@ -113,7 +113,7 @@ object FunctionalDataStructuresSection
    * `dropWhile` extends the behaviour of `drop`, removing elements from the `List` prefix as long as they match a
    * predicate. Study its implementation and check how it works with the following examples:
    */
-  def listDropWhileAssert(res0: List[Int], res1: List[Int], res2: List[Int], res3: List[Int]) {
+  def listDropWhileAssert(res0: List[Int], res1: List[Int], res2: List[Int], res3: List[Int]) = {
     def dropWhile[A](l: List[A], f: A => Boolean): List[A] =
       l match {
         case Cons(h, t) if f(h) => dropWhile(t, f)
@@ -131,7 +131,7 @@ object FunctionalDataStructuresSection
    *
    * `init` can be implemented in the same fashion, but cannot be implemented in constant time like `tail`:
    */
-  def listInitAssert(res0: List[Int], res1: List[Int]) {
+  def listInitAssert(res0: List[Int], res1: List[Int]) = {
     def init[A](l: List[A]): List[A] =
       l match {
         case Nil          => sys.error("init of empty list")
@@ -161,7 +161,7 @@ object FunctionalDataStructuresSection
       res7: Int,
       res8: Int,
       res9: Int,
-      res10: Int) {
+      res10: Int) = {
     foldRight(Cons(1, Cons(2, Cons(3, Nil))), 0)((x, y) => x + y) shouldBe 6
     res0 + foldRight(Cons(2, Cons(3, Nil)), 0)((x, y) => x + y) shouldBe 6
     res1 + res2 + foldRight(Cons(3, Nil), 0)((x, y) => x + y) shouldBe 6
@@ -175,9 +175,8 @@ object FunctionalDataStructuresSection
    * Now that we know how `foldRight` works, try to think about what happens when you pass `Nil` and `Cons` themselves
    * to `foldRight`.
    */
-  def listFoldRightNilConsAssert(res0: List[Int]) {
+  def listFoldRightNilConsAssert(res0: List[Int]) =
     foldRight(List(1, 2, 3), Nil: List[Int])(Cons(_, _)) shouldBe res0
-  }
 
   /**
    * <b>Exercise 3.9:</b>

--- a/src/main/scala/fpinscalalib/GettingStartedWithFPSection.scala
+++ b/src/main/scala/fpinscalalib/GettingStartedWithFPSection.scala
@@ -33,12 +33,12 @@ object GettingStartedWithFPSection
    * Try to fix the `loop` function inside `fib` so that it returns the correct values for each case in a tail-recursive
    * way. What should the missing expressions for the trivial case and the recursive call be?
    */
-  def fibAssert(res0: Int, res1: Int) {
+  def fibAssert(res0: Int) = {
     def fib(n: Int): Int = {
       @annotation.tailrec
       def loop(n: Int, prev: Int, cur: Int): Int =
         if (n <= res0) prev
-        else loop(n - res1, cur, prev + cur)
+        else loop(n - 1, cur, prev + cur)
       loop(n, 0, 1)
     }
 

--- a/src/main/scala/fpinscalalib/StrictnessAndLazinessSection.scala
+++ b/src/main/scala/fpinscalalib/StrictnessAndLazinessSection.scala
@@ -31,6 +31,12 @@ object StrictnessAndLazinessSection
    *
    * = Strict and non-strict functions =
    *
+   * <b>NOTE:</b> This section is only for educational purposes. In Scala 2.13, scala.collection.immutable.Stream
+   * is deprecated and scala.collection.immutable.LazyList is recommended for replacement. For more information,
+   * check the Scala [[https://www.scala-lang.org/files/archive/api/2.13.1/scala/collection/immutable/Stream.html Stream]]
+   * and [[https://www.scala-lang.org/files/archive/api/2.13.1/scala/collection/immutable/LazyList.html LazyList]]
+   * documentation.
+   *
    * <b>Exercise 5.1:</b>
    *
    * Now let's write a few helper functions to make inspecting streams easier, starting with a function to convert a

--- a/src/main/scala/fpinscalalib/customlib/functionalparallelism/ParHelper.scala
+++ b/src/main/scala/fpinscalalib/customlib/functionalparallelism/ParHelper.scala
@@ -13,7 +13,6 @@ package fpinscalalib.customlib.functionalparallelism
 // https://github.com/fpinscala/fpinscala/blob/a261989ae4e779b45c7176273dbd2349f487b7d1/answers/src/main/scala/fpinscala/parallelism/Par.scala
 
 import java.util.concurrent._
-import language.implicitConversions
 
 object Par {
   type Par[A] = ExecutorService => Future[A]

--- a/src/main/scala/fpinscalalib/customlib/parsing/JSON.scala
+++ b/src/main/scala/fpinscalalib/customlib/parsing/JSON.scala
@@ -12,9 +12,6 @@ package fpinscalalib.customlib.parsing
 //
 // https://github.com/fpinscala/fpinscala/blob/44e01a7b5cc68cd681f182274b3a605db1bcff6c/answers/src/main/scala/fpinscala/parsing/JSON.scala
 
-import language.higherKinds
-import language.implicitConversions
-
 trait JSON
 
 object JSON {

--- a/src/main/scala/fpinscalalib/customlib/parsing/ParsersHelper.scala
+++ b/src/main/scala/fpinscalalib/customlib/parsing/ParsersHelper.scala
@@ -16,8 +16,6 @@ import java.util.regex._
 import scala.util.matching.Regex
 import fpinscalalib.customlib.testing._
 import fpinscalalib.customlib.testing.Prop._
-import language.higherKinds
-import language.implicitConversions
 
 trait Parsers[Parser[+ _]] { self => // so inner classes may call methods of trait
   def run[A](p: Parser[A])(input: String): Either[ParseError, A]
@@ -250,9 +248,9 @@ case class ParseError(stack: List[(Location, String)] = List()) {
    * messages at the same location have their messages merged,
    * separated by semicolons */
   def collapseStack(s: List[(Location, String)]): List[(Location, String)] =
-    s.groupBy(_._1).mapValues(_.map(_._2).mkString("; ")).toList.sortBy(_._1.offset)
+    s.groupBy(_._1).view.mapValues(_.map(_._2).mkString("; ")).toList.sortBy(_._1.offset)
 
-  def formatLoc(l: Location): String = l.line + "." + l.col
+  def formatLoc(l: Location): String = s"${l.line}.${l.col}"
 }
 
 object Parsers {}

--- a/src/main/scala/fpinscalalib/customlib/testing/GenHelper.scala
+++ b/src/main/scala/fpinscalalib/customlib/testing/GenHelper.scala
@@ -22,7 +22,6 @@ import fpinscalalib.customlib.state.{RNG, State}
 import fpinscalalib.customlib.laziness.Stream
 
 import language.postfixOps
-import language.implicitConversions
 
 case class Prop(run: (MaxSize, TestCases, RNG) => Result) {
   def &&(p: Prop) = Prop { (max, n, rng) =>

--- a/src/test/scala/fpinscalalib/GettingStartedWithFPSpec.scala
+++ b/src/test/scala/fpinscalalib/GettingStartedWithFPSpec.scala
@@ -23,7 +23,7 @@ class GettingStartedWithFPSpec extends RefSpec with Checkers {
       } yield res0 :: res1 :: HNil
     }
 
-    check(Test.testSuccess(GettingStartedWithFPSection.fibAssert _, 0 :: 1 :: HNil))
+    check(Test.testSuccess(GettingStartedWithFPSection.fibAssert _, 0 :: HNil))
   }
 
   def `isSorted asserts`() =

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.5.0-SNAPSHOT"
+version in ThisBuild := "0.6.0-SNAPSHOT"


### PR DESCRIPTION
This PR updates the library to Scala 2.13.1 and its exercises to avoid deprecation warnings.