### PR TITLE
Fix 'take' method in exercise 5.2

### DIFF
--- a/src/main/scala/fpinscalalib/StrictnessAndLazinessSection.scala
+++ b/src/main/scala/fpinscalalib/StrictnessAndLazinessSection.scala
@@ -71,7 +71,6 @@ object StrictnessAndLazinessSection
   def streamTakeAssert(res0: Int): Unit = {
     def take[A](s: Stream[A], n: Int): Stream[A] = s match {
       case Cons(h, t) if n > 0  => cons[A](h(), t().take(n - res0))
-      case Cons(h, _) if n == 0 => cons[A](h(), Stream.empty)
       case _                    => Stream.empty
     }
 


### PR DESCRIPTION
Calling `take(s, 0)` with non-empty s returns a stream with one (first) element, when it should return empty stream (apart from this being the behaviour of Scala's List and LazyList, it just seems natural to get empty stream after asking "to take zero elements from this stream").