### PR TITLE
world's tiniest typo

### DIFF
--- a/src/main/scala/fpinscalalib/FunctionalStateSection.scala
+++ b/src/main/scala/fpinscalalib/FunctionalStateSection.scala
@@ -43,7 +43,7 @@ object FunctionalStateSection
    *
    * <b>Exercise 6.1:</b>
    *
-   * Let's write a function that uses `RNG.nextInt` to generate a random integer between `0` and `Int.maxValue`, making
+   * Let's write a function that uses `RNG.nextInt` to generate a random integer between `0` and `Int.MaxValue`, making
    * sure to handle the corner case when `nextInt` returns `Int.MinValue`, which doesn't have a non-negative
    * counterpart:
    */


### PR DESCRIPTION
`Int.maxValue` doesn't compile and considering that's the value that the user is supposed to pass into the method on the next line as one of the parameters it probably makes sense to have this example compile.